### PR TITLE
`use` DynTrait with visibility of original trait

### DIFF
--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -150,6 +150,7 @@ pub fn dynosaur(
         }
     }
 
+    let vis = &item_trait.vis;
     let struct_ident = &attrs.ident;
     let expanded_trait_to_dyn = expand_trait_async_fns_to_dyn(&item_trait);
     let erased_trait = mk_erased_trait(&expanded_trait_to_dyn);
@@ -178,7 +179,7 @@ pub fn dynosaur(
             #struct_inherent_impl
         }
 
-        use #dynosaur_mod::#struct_ident;
+        #vis use #dynosaur_mod::#struct_ident;
     }
     .into()
 }


### PR DESCRIPTION
Previously, the DynTrait struct would be privately imported into the defining scope,
and you'd need to do something like the following to make the DynTrait pub:

```rust
mod m {
    #[dynosaur::dynosaur(DynTrait)]
    pub trait Trait {
        async fn foo(&self); 
    }
    pub type PubDynTrait<'a> = DynTrait<'a>;
}
pub use {m::Trait, m::PubDynTrait as DynTrait};
```

After this PR, that becomes
```rust
#[dynosaur::dynosaur(DynTrait)]
pub trait Trait {
    async fn foo(&self); 
}
```

and if you want to make the `DynTrait` private, you would do

```rust
mod m {
    #[dynosaur::dynosaur(DynTrait)]
    pub trait Trait {
        async fn foo(&self); 
    }
}
pub use m::Trait;
```

which I think is a more sane default
