### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ methods returning `impl Trait`.
 #[dynosaur::dynosaur(DynNext)]
 trait Next {
     type Item;
-    async fn next(&mut self) -> Self::Item;
+    async fn next(&mut self) -> Option<Self::Item>;
 }
 ```
 


### PR DESCRIPTION
I don't know if we should also add the following code, so you can actually run the example.

```rust
impl<Item, T: Iterator<Item = Item>> Next for T {
    type Item = Item;

    async fn next(&mut self) -> Option<Self::Item>  {
        self.next()
    }
}
```