### PR TITLE
Move trait-variant into a dev-dependency

### DIFF
--- a/dynosaur/Cargo.toml
+++ b/dynosaur/Cargo.toml
@@ -17,10 +17,10 @@ rust-version = "1.75"
 
 [dependencies]
 dynosaur_derive = { version = "0.2", path = "../dynosaur_derive" }
-trait-variant = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+trait-variant = { workspace = true }
 ui_test = "0.28"
 
 [[example]]


### PR DESCRIPTION
It seems dynosaur is not using `trait-variant` as part of the library, only in an example, so this moves that dependency to be a dev-dependency.