### PR TITLE
Consts make trait not dyn compatible but generate something 'better' …

### DIFF
--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -227,6 +227,8 @@ fn mk_erased_trait_blanket_impl(item_trait: &ItemTrait) -> TokenStream {
                     ty,
                     ..
                 }) => {
+                    // const makes the trait not dyn compatible, so whatever we do here is going to fail.
+                    // We should probably do a better error handling at some point.
                     quote! {
                         const #ident #generics: #ty = <Self as #trait_ident #trait_generics>::#ident;
                     }
@@ -288,6 +290,8 @@ fn mk_dyn_struct_impl_item(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
             ty,
             ..
         }) => {
+            // const makes the trait not dyn compatible, so whatever we do here is going to fail.
+            // We should probably do a better error handling at some point.
             quote! {
                 const #ident #generics: #ty = <Self as #item_trait_ident #trait_generics>::#ident;
             }


### PR DESCRIPTION
Not sure what to do exactly with const generation as once a trait has a const is no longer dyn compatible. Probably generating something as best as possible is the best thing to do and leave the compiler fail properly afterwards.
In this case, this change is better as with the old generation overflows.

r? @tmandry 