### PR TITLE
feat: make from_ref, from_mut const-fn

### DIFF
--- a/dynosaur/tests/pass/anynomous-args.stdout
+++ b/dynosaur/tests/pass/anynomous-args.stdout
@@ -75,12 +75,12 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/associated-types.stdout
+++ b/dynosaur/tests/pass/associated-types.stdout
@@ -74,13 +74,15 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl Foo<Bar = Bar> + 'dynosaur_struct))
+        pub const fn from_ref(value:
+                &(impl Foo<Bar = Bar> + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct, Bar> {
             let value: &(dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl Foo<Bar = Bar> + 'dynosaur_struct))
+        pub const fn from_mut(value:
+                &mut (impl Foo<Bar = Bar> + 'dynosaur_struct))
             -> &mut DynFoo<'dynosaur_struct, Bar> {
             let value: &mut (dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/async-and-non-async.stdout
+++ b/dynosaur/tests/pass/async-and-non-async.stdout
@@ -69,12 +69,12 @@ mod __dynosaur_macro_dynjobqueue {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
             -> &DynJobQueue<'dynosaur_struct> {
             let value: &(dyn ErasedJobQueue + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl JobQueue + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl JobQueue + 'dynosaur_struct))
             -> &mut DynJobQueue<'dynosaur_struct> {
             let value: &mut (dyn ErasedJobQueue + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/basic-apit.stdout
+++ b/dynosaur/tests/pass/basic-apit.stdout
@@ -96,12 +96,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/basic-mut.stdout
+++ b/dynosaur/tests/pass/basic-mut.stdout
@@ -63,12 +63,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/basic-no-ret.stdout
+++ b/dynosaur/tests/pass/basic-no-ret.stdout
@@ -63,12 +63,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/basic-rpitit.stdout
+++ b/dynosaur/tests/pass/basic-rpitit.stdout
@@ -57,12 +57,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/basic-with-self.stdout
+++ b/dynosaur/tests/pass/basic-with-self.stdout
@@ -75,14 +75,14 @@ mod __dynosaur_macro_dynmytrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value:
+        pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {
             let value: &(dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value:
+        pub const fn from_mut(value:
                 &mut (impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct, Item> {
             let value:

--- a/dynosaur/tests/pass/basic.stdout
+++ b/dynosaur/tests/pass/basic.stdout
@@ -64,12 +64,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/default-method-trait.stdout
+++ b/dynosaur/tests/pass/default-method-trait.stdout
@@ -57,12 +57,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/handle-lifetimes.stdout
+++ b/dynosaur/tests/pass/handle-lifetimes.stdout
@@ -75,14 +75,14 @@ mod __dynosaur_macro_dynmytrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value:
+        pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {
             let value: &(dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value:
+        pub const fn from_mut(value:
                 &mut (impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct, Item> {
             let value:

--- a/dynosaur/tests/pass/impl-future-bounds.stdout
+++ b/dynosaur/tests/pass/impl-future-bounds.stdout
@@ -61,12 +61,12 @@ mod __dynosaur_macro_dynfoo {
             let value: std::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl Foo + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct> {
             let value: &(dyn ErasedFoo + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl Foo + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl Foo + 'dynosaur_struct))
             -> &mut DynFoo<'dynosaur_struct> {
             let value: &mut (dyn ErasedFoo + 'dynosaur_struct) = &mut *value;
             unsafe { ::core::mem::transmute(value) }

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
@@ -84,13 +84,14 @@ mod __dynosaur_macro_dynsometrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl SomeTrait<'a, 'b> + 'dynosaur_struct))
+        pub const fn from_ref(value:
+                &(impl SomeTrait<'a, 'b> + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct, 'a, 'b> {
             let value: &(dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value:
+        pub const fn from_mut(value:
                 &mut (impl SomeTrait<'a, 'b> + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct, 'a, 'b> {
             let value: &mut (dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/multiple-lifetimes.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes.stdout
@@ -169,12 +169,12 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/non-future-impl-traits.stdout
+++ b/dynosaur/tests/pass/non-future-impl-traits.stdout
@@ -57,12 +57,12 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/trait-variant.stdout
+++ b/dynosaur/tests/pass/trait-variant.stdout
@@ -74,13 +74,14 @@ mod __dynosaur_macro_dynnext {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl Next<Item = Item> + 'dynosaur_struct))
+        pub const fn from_ref(value:
+                &(impl Next<Item = Item> + 'dynosaur_struct))
             -> &DynNext<'dynosaur_struct, Item> {
             let value: &(dyn ErasedNext<Item = Item> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value:
+        pub const fn from_mut(value:
                 &mut (impl Next<Item = Item> + 'dynosaur_struct))
             -> &mut DynNext<'dynosaur_struct, Item> {
             let value: &mut (dyn ErasedNext<Item = Item> + 'dynosaur_struct) =
@@ -163,14 +164,14 @@ mod __dynosaur_macro_dynsendnext {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value:
+        pub const fn from_ref(value:
                 &(impl SendNext<Item = Item> + 'dynosaur_struct))
             -> &DynSendNext<'dynosaur_struct, Item> {
             let value: &(dyn ErasedSendNext<Item = Item> + 'dynosaur_struct) =
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value:
+        pub const fn from_mut(value:
                 &mut (impl SendNext<Item = Item> + 'dynosaur_struct))
             -> &mut DynSendNext<'dynosaur_struct, Item> {
             let value:

--- a/dynosaur/tests/pass/visibility.stdout
+++ b/dynosaur/tests/pass/visibility.stdout
@@ -64,12 +64,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/where-self-sized-rpit.stdout
+++ b/dynosaur/tests/pass/where-self-sized-rpit.stdout
@@ -77,12 +77,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur/tests/pass/where-self-sized.stdout
+++ b/dynosaur/tests/pass/where-self-sized.stdout
@@ -70,12 +70,12 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
+        pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
+        pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =
                 &mut *value;

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -373,12 +373,12 @@ fn mk_struct_inherent_impl(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn from_ref(value: &(impl #trait_ident #trait_params + 'dynosaur_struct)) -> & #struct_ident #struct_params {
+            pub const fn from_ref(value: &(impl #trait_ident #trait_params + 'dynosaur_struct)) -> & #struct_ident #struct_params {
                 let value: &(dyn #erased_trait_ident #trait_params + 'dynosaur_struct) = &*value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn from_mut(value: &mut (impl #trait_ident #trait_params + 'dynosaur_struct)) -> &mut #struct_ident #struct_params {
+            pub const fn from_mut(value: &mut (impl #trait_ident #trait_params + 'dynosaur_struct)) -> &mut #struct_ident #struct_params {
                 let value: &mut (dyn #erased_trait_ident #trait_params + 'dynosaur_struct) = &mut *value;
                 unsafe { ::core::mem::transmute(value) }
             }


### PR DESCRIPTION
- `mem::transmute` has been const since rust 1.56
- I need this to be able to use dynosaur with `const` items that implement a trait

---

Cool crate btw, very nicely done. 