### PR TITLE
Finishing touches for 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Currently Rust does not support dynamic dispatch on traits that use `async fn` o
 This removes the need for the use of the `async_trait` proc macro, giving users the performance benefits of static dispatch without giving up the flexibility of dynamic dispatch.
 
 ```rust,ignore
-#[dynosaur::dynosaur(DynNext = dyn(box))]
+#[dynosaur::dynosaur(DynNext = dyn(box) Next)]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Currently Rust does not support dynamic dispatch on traits that use `async fn` o
 This removes the need for the use of the `async_trait` proc macro, giving users the performance benefits of static dispatch without giving up the flexibility of dynamic dispatch.
 
 ```rust,ignore
-#[dynosaur::dynosaur(DynNext)]
+#[dynosaur::dynosaur(DynNext = dyn(box))]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/examples/default_trait.rs
+++ b/dynosaur/examples/default_trait.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[dynosaur::dynosaur(DynFoo = dyn(box))]
+#[dynosaur::dynosaur(DynFoo = dyn(box) Foo)]
 trait Foo {
     fn foo(&self) -> impl Display {
         1

--- a/dynosaur/examples/default_trait.rs
+++ b/dynosaur/examples/default_trait.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[dynosaur::dynosaur(DynFoo)]
+#[dynosaur::dynosaur(DynFoo = dyn(box))]
 trait Foo {
     fn foo(&self) -> impl Display {
         1

--- a/dynosaur/examples/next.rs
+++ b/dynosaur/examples/next.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynNext)]
+#[dynosaur::dynosaur(DynNext = dyn(box))]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/examples/next.rs
+++ b/dynosaur/examples/next.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynNext = dyn(box))]
+#[dynosaur::dynosaur(DynNext = dyn(box) Next)]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/examples/trait_variant.rs
+++ b/dynosaur/examples/trait_variant.rs
@@ -1,6 +1,6 @@
 #[trait_variant::make(SendNext: Send)]
-#[dynosaur::dynosaur(DynNext = dyn Next, bridge(dyn))]
-#[dynosaur::dynosaur(DynSendNext = dyn SendNext, bridge(dyn))]
+#[dynosaur::dynosaur(DynNext = dyn(box) Next, bridge(dyn))]
+#[dynosaur::dynosaur(DynSendNext = dyn(box) SendNext, bridge(dyn))]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/examples/trait_variant.rs
+++ b/dynosaur/examples/trait_variant.rs
@@ -42,7 +42,7 @@ async fn static_dispatch_local(mut iter: impl Next<Item = i32>) {
 async fn main() {
     let v = [1, 2, 3];
     dyn_dispatch(&mut DynSendNext::new_box(from_iter(v))).await;
-    dyn_dispatch(&mut DynSendNext::new_box(from_iter(v))).await;
+    dyn_dispatch(&mut DynSendNext::from_box(Box::new(from_iter(v)))).await;
     dyn_dispatch_local(DynNext::from_mut(&mut from_iter(v))).await;
     dyn_dispatch_local(DynNext::from_mut(&mut from_iter(v))).await;
     static_dispatch(from_iter(v)).await;

--- a/dynosaur/tests/fail/const-attr.rs
+++ b/dynosaur/tests/fail/const-attr.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynFoo = dyn(box))]
+#[dynosaur::dynosaur(DynFoo = dyn(box) Foo)]
 trait Foo {
     const BAR: i32;
 

--- a/dynosaur/tests/fail/const-attr.rs
+++ b/dynosaur/tests/fail/const-attr.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynFoo)]
+#[dynosaur::dynosaur(DynFoo = dyn(box))]
 trait Foo {
     const BAR: i32;
 

--- a/dynosaur/tests/fail/const-attr.stdout
+++ b/dynosaur/tests/fail/const-attr.stdout
@@ -57,6 +57,11 @@ mod __dynosaur_macro_dynfoo {
             let value: std::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl Foo + 'dynosaur_struct>)
+            -> Box<DynFoo<'dynosaur_struct>> {
+            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct> {
             let value: &(dyn ErasedFoo + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/fail/missing-strategy.rs
+++ b/dynosaur/tests/fail/missing-strategy.rs
@@ -1,0 +1,13 @@
+use dynosaur::dynosaur;
+
+#[dynosaur(DynMyTrait = dyn)]
+trait MyTrait {
+    async fn foo(&self) -> i32;
+}
+
+#[dynosaur(DynMyTrait2 = dyn MyTrait2)]
+trait MyTrait2 {
+    async fn foo(&self) -> i32;
+}
+
+fn main() {}

--- a/dynosaur/tests/fail/missing-strategy.rs
+++ b/dynosaur/tests/fail/missing-strategy.rs
@@ -10,4 +10,9 @@ trait MyTrait2 {
     async fn foo(&self) -> i32;
 }
 
+#[dynosaur(DynMyTrait3 = dyn(box))]
+trait MyTrait3 {
+    async fn foo(&self) -> i32;
+}
+
 fn main() {}

--- a/dynosaur/tests/fail/missing-strategy.stderr
+++ b/dynosaur/tests/fail/missing-strategy.stderr
@@ -10,5 +10,13 @@ error: expected `dyn(box)`
 8 | #[dynosaur(DynMyTrait2 = dyn MyTrait2)]
   |                          ^^^
 
-error: aborting due to 2 previous errors
+error: unexpected end of input, expected trait name after `dyn(box)`
+  --> tests/fail/missing-strategy.rs:13:1
+   |
+13 | #[dynosaur(DynMyTrait3 = dyn(box))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `dynosaur` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
 

--- a/dynosaur/tests/fail/missing-strategy.stderr
+++ b/dynosaur/tests/fail/missing-strategy.stderr
@@ -1,0 +1,14 @@
+error: expected `dyn(box)`
+ --> tests/fail/missing-strategy.rs:3:25
+  |
+3 | #[dynosaur(DynMyTrait = dyn)]
+  |                         ^^^
+
+error: expected `dyn(box)`
+ --> tests/fail/missing-strategy.rs:8:26
+  |
+8 | #[dynosaur(DynMyTrait2 = dyn MyTrait2)]
+  |                          ^^^
+
+error: aborting due to 2 previous errors
+

--- a/dynosaur/tests/fail/missing-strategy.stdout
+++ b/dynosaur/tests/fail/missing-strategy.stdout
@@ -1,0 +1,10 @@
+#![feature(prelude_import)]
+#[prelude_import]
+use std::prelude::rust_2021::*;
+#[macro_use]
+extern crate std;
+use dynosaur::dynosaur;
+
+
+
+fn main() {}

--- a/dynosaur/tests/fail/missing-strategy.stdout
+++ b/dynosaur/tests/fail/missing-strategy.stdout
@@ -7,4 +7,5 @@ use dynosaur::dynosaur;
 
 
 
+
 fn main() {}

--- a/dynosaur/tests/fail/self_and_box_receivers.rs
+++ b/dynosaur/tests/fail/self_and_box_receivers.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-#[dynosaur::dynosaur(DynAll = dyn(box))]
+#[dynosaur::dynosaur(DynAll = dyn(box) All)]
 trait All {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;

--- a/dynosaur/tests/fail/self_and_box_receivers.rs
+++ b/dynosaur/tests/fail/self_and_box_receivers.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-#[dynosaur::dynosaur(DynAll)]
+#[dynosaur::dynosaur(DynAll = dyn(box))]
 trait All {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;

--- a/dynosaur/tests/fail/self_and_box_receivers.stdout
+++ b/dynosaur/tests/fail/self_and_box_receivers.stdout
@@ -108,6 +108,11 @@ mod __dynosaur_macro_dynall {
             let value: std::rc::Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl All + 'dynosaur_struct>)
+            -> Box<DynAll<'dynosaur_struct>> {
+            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))
             -> &DynAll<'dynosaur_struct> {
             let value: &(dyn ErasedAll + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/fail/where-self-sized-rpit.rs
+++ b/dynosaur/tests/fail/where-self-sized-rpit.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()>
     where

--- a/dynosaur/tests/fail/where-self-sized-rpit.rs
+++ b/dynosaur/tests/fail/where-self-sized-rpit.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     fn foo(&mut self) -> impl ::core::future::Future<Output = ()>
     where

--- a/dynosaur/tests/fail/where-self-sized-rpit.stdout
+++ b/dynosaur/tests/fail/where-self-sized-rpit.stdout
@@ -69,6 +69,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/fail/where-self-sized.rs
+++ b/dynosaur/tests/fail/where-self-sized.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     async fn foo(&mut self)
     where

--- a/dynosaur/tests/fail/where-self-sized.rs
+++ b/dynosaur/tests/fail/where-self-sized.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     async fn foo(&mut self)
     where

--- a/dynosaur/tests/fail/where-self-sized.stdout
+++ b/dynosaur/tests/fail/where-self-sized.stdout
@@ -62,6 +62,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/anynomous-args.rs
+++ b/dynosaur/tests/pass/anynomous-args.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box) SomeTrait)]
 trait SomeTrait {
     async fn multiple_elided_lifetimes(&self, _: &u8, _: &u8);
 }

--- a/dynosaur/tests/pass/anynomous-args.rs
+++ b/dynosaur/tests/pass/anynomous-args.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait)]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
 trait SomeTrait {
     async fn multiple_elided_lifetimes(&self, _: &u8, _: &u8);
 }

--- a/dynosaur/tests/pass/anynomous-args.stdout
+++ b/dynosaur/tests/pass/anynomous-args.stdout
@@ -75,6 +75,11 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
+            -> Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/associated-types.rs
+++ b/dynosaur/tests/pass/associated-types.rs
@@ -1,6 +1,6 @@
 trait Baz {}
 
-#[dynosaur::dynosaur(DynFoo)]
+#[dynosaur::dynosaur(DynFoo = dyn(box))]
 trait Foo {
     type Bar: Baz;
 

--- a/dynosaur/tests/pass/associated-types.rs
+++ b/dynosaur/tests/pass/associated-types.rs
@@ -1,6 +1,6 @@
 trait Baz {}
 
-#[dynosaur::dynosaur(DynFoo = dyn(box))]
+#[dynosaur::dynosaur(DynFoo = dyn(box) Foo)]
 trait Foo {
     type Bar: Baz;
 

--- a/dynosaur/tests/pass/associated-types.stdout
+++ b/dynosaur/tests/pass/associated-types.stdout
@@ -74,6 +74,13 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl Foo<Bar = Bar> + 'dynosaur_struct>)
+            -> Box<DynFoo<'dynosaur_struct, Bar>> {
+            let value: Box<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl Foo<Bar = Bar> + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct, Bar> {

--- a/dynosaur/tests/pass/async-and-non-async.rs
+++ b/dynosaur/tests/pass/async-and-non-async.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynJobQueue = dyn(box))]
+#[dynosaur(DynJobQueue = dyn(box) JobQueue)]
 pub trait JobQueue {
     fn len(&self) -> usize;
     async fn dispatch(&self);

--- a/dynosaur/tests/pass/async-and-non-async.rs
+++ b/dynosaur/tests/pass/async-and-non-async.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynJobQueue)]
+#[dynosaur(DynJobQueue = dyn(box))]
 pub trait JobQueue {
     fn len(&self) -> usize;
     async fn dispatch(&self);

--- a/dynosaur/tests/pass/async-and-non-async.stdout
+++ b/dynosaur/tests/pass/async-and-non-async.stdout
@@ -69,6 +69,11 @@ mod __dynosaur_macro_dynjobqueue {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl JobQueue + 'dynosaur_struct>)
+            -> Box<DynJobQueue<'dynosaur_struct>> {
+            let value: Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
             -> &DynJobQueue<'dynosaur_struct> {
             let value: &(dyn ErasedJobQueue + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/basic-apit.rs
+++ b/dynosaur/tests/pass/basic-apit.rs
@@ -5,7 +5,7 @@ trait Foo {}
 
 impl Foo for Box<dyn Foo + '_> {}
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     fn foo(&self, _: impl Foo) -> i32;
     async fn bar(&self, _: impl Foo) -> i32;

--- a/dynosaur/tests/pass/basic-apit.rs
+++ b/dynosaur/tests/pass/basic-apit.rs
@@ -5,7 +5,7 @@ trait Foo {}
 
 impl Foo for Box<dyn Foo + '_> {}
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     fn foo(&self, _: impl Foo) -> i32;
     async fn bar(&self, _: impl Foo) -> i32;

--- a/dynosaur/tests/pass/basic-apit.stdout
+++ b/dynosaur/tests/pass/basic-apit.stdout
@@ -96,6 +96,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/basic-mut.rs
+++ b/dynosaur/tests/pass/basic-mut.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     async fn foo(&mut self);
 }

--- a/dynosaur/tests/pass/basic-mut.rs
+++ b/dynosaur/tests/pass/basic-mut.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     async fn foo(&mut self);
 }

--- a/dynosaur/tests/pass/basic-mut.stdout
+++ b/dynosaur/tests/pass/basic-mut.stdout
@@ -63,6 +63,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/basic-no-ret.rs
+++ b/dynosaur/tests/pass/basic-no-ret.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     async fn foo(&self);
 }

--- a/dynosaur/tests/pass/basic-no-ret.rs
+++ b/dynosaur/tests/pass/basic-no-ret.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     async fn foo(&self);
 }

--- a/dynosaur/tests/pass/basic-no-ret.stdout
+++ b/dynosaur/tests/pass/basic-no-ret.stdout
@@ -63,6 +63,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/basic-rpitit.rs
+++ b/dynosaur/tests/pass/basic-rpitit.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     fn foo(&self) -> impl Send;
 }

--- a/dynosaur/tests/pass/basic-rpitit.rs
+++ b/dynosaur/tests/pass/basic-rpitit.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     fn foo(&self) -> impl Send;
 }

--- a/dynosaur/tests/pass/basic-rpitit.stdout
+++ b/dynosaur/tests/pass/basic-rpitit.stdout
@@ -57,6 +57,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/basic-with-self.rs
+++ b/dynosaur/tests/pass/basic-with-self.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     type Item;
     async fn foo(&self) -> Self::Item;

--- a/dynosaur/tests/pass/basic-with-self.rs
+++ b/dynosaur/tests/pass/basic-with-self.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     type Item;
     async fn foo(&self) -> Self::Item;

--- a/dynosaur/tests/pass/basic-with-self.stdout
+++ b/dynosaur/tests/pass/basic-with-self.stdout
@@ -75,6 +75,14 @@ mod __dynosaur_macro_dynmytrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/basic.rs
+++ b/dynosaur/tests/pass/basic.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     async fn foo(&self) -> i32;
 }

--- a/dynosaur/tests/pass/basic.rs
+++ b/dynosaur/tests/pass/basic.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     async fn foo(&self) -> i32;
 }

--- a/dynosaur/tests/pass/basic.stdout
+++ b/dynosaur/tests/pass/basic.stdout
@@ -64,6 +64,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/bridge-attr.rs
+++ b/dynosaur/tests/pass/bridge-attr.rs
@@ -1,16 +1,16 @@
-#[dynosaur::dynosaur(DynNextNone, bridge(none))]
+#[dynosaur::dynosaur(DynNextNone = dyn(box), bridge(none))]
 trait NextNone {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;
 }
 
-#[dynosaur::dynosaur(DynNextDefault, bridge(static))]
+#[dynosaur::dynosaur(DynNextDefault = dyn(box), bridge(static))]
 trait NextDefault {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;
 }
 
-#[dynosaur::dynosaur(DynNextDyn, bridge(dyn))]
+#[dynosaur::dynosaur(DynNextDyn = dyn(box), bridge(dyn))]
 trait NextDyn {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/tests/pass/bridge-attr.rs
+++ b/dynosaur/tests/pass/bridge-attr.rs
@@ -1,16 +1,16 @@
-#[dynosaur::dynosaur(DynNextNone = dyn(box), bridge(none))]
+#[dynosaur::dynosaur(DynNextNone = dyn(box) NextNone, bridge(none))]
 trait NextNone {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;
 }
 
-#[dynosaur::dynosaur(DynNextDefault = dyn(box), bridge(blanket))]
+#[dynosaur::dynosaur(DynNextDefault = dyn(box) NextDefault, bridge(blanket))]
 trait NextDefault {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;
 }
 
-#[dynosaur::dynosaur(DynNextDyn = dyn(box), bridge(dyn))]
+#[dynosaur::dynosaur(DynNextDyn = dyn(box) NextDyn, bridge(dyn))]
 trait NextDyn {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/tests/pass/bridge-attr.rs
+++ b/dynosaur/tests/pass/bridge-attr.rs
@@ -4,7 +4,7 @@ trait NextNone {
     async fn next(&mut self) -> Option<Self::Item>;
 }
 
-#[dynosaur::dynosaur(DynNextDefault = dyn(box), bridge(static))]
+#[dynosaur::dynosaur(DynNextDefault = dyn(box), bridge(blanket))]
 trait NextDefault {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/tests/pass/bridge-attr.stdout
+++ b/dynosaur/tests/pass/bridge-attr.stdout
@@ -74,6 +74,14 @@ mod __dynosaur_macro_dynnextnone {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl NextNone<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynNextNone<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl NextNone<Item = Item> + 'dynosaur_struct))
             -> &DynNextNone<'dynosaur_struct, Item> {
@@ -164,6 +172,14 @@ mod __dynosaur_macro_dynnextdefault {
             let value:
                     std::rc::Rc<dyn ErasedNextDefault<Item = Item> +
                     'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
+        pub const fn from_box(value:
+                Box<impl NextDefault<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynNextDefault<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedNextDefault<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -271,6 +287,14 @@ mod __dynosaur_macro_dynnextdyn {
             let value:
                     std::rc::Rc<dyn ErasedNextDyn<Item = Item> +
                     'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
+        pub const fn from_box(value:
+                Box<impl NextDyn<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynNextDyn<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:

--- a/dynosaur/tests/pass/default-method-trait.rs
+++ b/dynosaur/tests/pass/default-method-trait.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     fn foo(&mut self) -> impl Send {
         10

--- a/dynosaur/tests/pass/default-method-trait.rs
+++ b/dynosaur/tests/pass/default-method-trait.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     fn foo(&mut self) -> impl Send {
         10

--- a/dynosaur/tests/pass/default-method-trait.stdout
+++ b/dynosaur/tests/pass/default-method-trait.stdout
@@ -57,6 +57,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/generics-in-trait-def.rs
+++ b/dynosaur/tests/pass/generics-in-trait-def.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[dynosaur::dynosaur(DynService)]
+#[dynosaur::dynosaur(DynService = dyn(box))]
 pub trait Service<Request> {
     type Response;
     type Error;

--- a/dynosaur/tests/pass/generics-in-trait-def.rs
+++ b/dynosaur/tests/pass/generics-in-trait-def.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[dynosaur::dynosaur(DynService = dyn(box))]
+#[dynosaur::dynosaur(DynService = dyn(box) Service)]
 pub trait Service<Request> {
     type Response;
     type Error;

--- a/dynosaur/tests/pass/generics-in-trait-def.stdout
+++ b/dynosaur/tests/pass/generics-in-trait-def.stdout
@@ -96,6 +96,15 @@ mod __dynosaur_macro_dynservice {
                     Error = Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl Service<Request, Response = Response, Error =
+                Error> + 'dynosaur_struct>)
+            -> Box<DynService<'dynosaur_struct, Request, Response, Error>> {
+            let value:
+                    Box<dyn ErasedService<Request, Response = Response, Error =
+                    Error> + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct))

--- a/dynosaur/tests/pass/handle-lifetimes.rs
+++ b/dynosaur/tests/pass/handle-lifetimes.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait)]
+#[dynosaur(DynMyTrait = dyn(box))]
 trait MyTrait {
     type Item;
     async fn foo(&self, x: &i32) -> i32;

--- a/dynosaur/tests/pass/handle-lifetimes.rs
+++ b/dynosaur/tests/pass/handle-lifetimes.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(DynMyTrait = dyn(box))]
+#[dynosaur(DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     type Item;
     async fn foo(&self, x: &i32) -> i32;

--- a/dynosaur/tests/pass/handle-lifetimes.stdout
+++ b/dynosaur/tests/pass/handle-lifetimes.stdout
@@ -75,6 +75,14 @@ mod __dynosaur_macro_dynmytrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/impl-future-bounds.rs
+++ b/dynosaur/tests/pass/impl-future-bounds.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[dynosaur::dynosaur(DynFoo = dyn(box))]
+#[dynosaur::dynosaur(DynFoo = dyn(box) Foo)]
 trait Foo: Send {
     fn foo(&self) -> impl Future<Output = i32> + Send;
 }

--- a/dynosaur/tests/pass/impl-future-bounds.rs
+++ b/dynosaur/tests/pass/impl-future-bounds.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-#[dynosaur::dynosaur(DynFoo)]
+#[dynosaur::dynosaur(DynFoo = dyn(box))]
 trait Foo: Send {
     fn foo(&self) -> impl Future<Output = i32> + Send;
 }

--- a/dynosaur/tests/pass/impl-future-bounds.stdout
+++ b/dynosaur/tests/pass/impl-future-bounds.stdout
@@ -61,6 +61,11 @@ mod __dynosaur_macro_dynfoo {
             let value: std::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl Foo + 'dynosaur_struct>)
+            -> Box<DynFoo<'dynosaur_struct>> {
+            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct> {
             let value: &(dyn ErasedFoo + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.rs
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box) SomeTrait)]
 trait SomeTrait<'a, 'b> {
     async fn lotsa_lifetimes<'d, 'e, 'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32) -> &'a u32
     where

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.rs
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait)]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
 trait SomeTrait<'a, 'b> {
     async fn lotsa_lifetimes<'d, 'e, 'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32) -> &'a u32
     where

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
@@ -84,6 +84,13 @@ mod __dynosaur_macro_dynsometrait {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
+            -> Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
+            let value: Box<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl SomeTrait<'a, 'b> + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct, 'a, 'b> {

--- a/dynosaur/tests/pass/multiple-lifetimes.rs
+++ b/dynosaur/tests/pass/multiple-lifetimes.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box) SomeTrait)]
 trait SomeTrait {
     async fn multiple_elided_lifetimes(&self, a: &u8, b: &u8);
     async fn multiple_named_lifetimes<'a, 'b: 'a>(&self, a: &'a u8, b: &'b u8, c: &u8);

--- a/dynosaur/tests/pass/multiple-lifetimes.rs
+++ b/dynosaur/tests/pass/multiple-lifetimes.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait)]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
 trait SomeTrait {
     async fn multiple_elided_lifetimes(&self, a: &u8, b: &u8);
     async fn multiple_named_lifetimes<'a, 'b: 'a>(&self, a: &'a u8, b: &'b u8, c: &u8);

--- a/dynosaur/tests/pass/multiple-lifetimes.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes.stdout
@@ -169,6 +169,11 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
+            -> Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/non-future-impl-traits.rs
+++ b/dynosaur/tests/pass/non-future-impl-traits.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box) SomeTrait)]
 trait SomeTrait {
     fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_;
 }

--- a/dynosaur/tests/pass/non-future-impl-traits.rs
+++ b/dynosaur/tests/pass/non-future-impl-traits.rs
@@ -1,4 +1,4 @@
-#[dynosaur::dynosaur(DynSomeTrait)]
+#[dynosaur::dynosaur(DynSomeTrait = dyn(box))]
 trait SomeTrait {
     fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_;
 }

--- a/dynosaur/tests/pass/non-future-impl-traits.stdout
+++ b/dynosaur/tests/pass/non-future-impl-traits.stdout
@@ -57,6 +57,11 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
+            -> Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.rs
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.rs
@@ -1,15 +1,15 @@
-#[dynosaur::dynosaur(DynRefOnly = dyn(box))]
+#[dynosaur::dynosaur(DynRefOnly = dyn(box) RefOnly)]
 trait RefOnly {
     fn ref_(&self);
 }
 
-#[dynosaur::dynosaur(DynMutAndRef = dyn(box))]
+#[dynosaur::dynosaur(DynMutAndRef = dyn(box) MutAndRef)]
 trait MutAndRef {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;
 }
 
-#[dynosaur::dynosaur(DynAll = dyn(box))]
+#[dynosaur::dynosaur(DynAll = dyn(box) All)]
 trait All {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.rs
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.rs
@@ -1,15 +1,15 @@
-#[dynosaur::dynosaur(DynRefOnly)]
+#[dynosaur::dynosaur(DynRefOnly = dyn(box))]
 trait RefOnly {
     fn ref_(&self);
 }
 
-#[dynosaur::dynosaur(DynMutAndRef)]
+#[dynosaur::dynosaur(DynMutAndRef = dyn(box))]
 trait MutAndRef {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;
 }
 
-#[dynosaur::dynosaur(DynAll)]
+#[dynosaur::dynosaur(DynAll = dyn(box))]
 trait All {
     fn ref_mut(&mut self);
     fn ref_(&self) -> impl Send;

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
@@ -42,6 +42,11 @@ mod __dynosaur_macro_dynrefonly {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl RefOnly + 'dynosaur_struct>)
+            -> Box<DynRefOnly<'dynosaur_struct>> {
+            let value: Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl RefOnly + 'dynosaur_struct))
             -> &DynRefOnly<'dynosaur_struct> {
             let value: &(dyn ErasedRefOnly + 'dynosaur_struct) = &*value;
@@ -121,6 +126,11 @@ mod __dynosaur_macro_dynmutandref {
             let value = std::rc::Rc::new(value);
             let value: std::rc::Rc<dyn ErasedMutAndRef + 'dynosaur_struct> =
                 value;
+            unsafe { ::core::mem::transmute(value) }
+        }
+        pub const fn from_box(value: Box<impl MutAndRef + 'dynosaur_struct>)
+            -> Box<DynMutAndRef<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MutAndRef + 'dynosaur_struct))
@@ -203,6 +213,11 @@ mod __dynosaur_macro_dynall {
             -> std::rc::Rc<DynAll<'dynosaur_struct>> {
             let value = std::rc::Rc::new(value);
             let value: std::rc::Rc<dyn ErasedAll + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
+        pub const fn from_box(value: Box<impl All + 'dynosaur_struct>)
+            -> Box<DynAll<'dynosaur_struct>> {
+            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))

--- a/dynosaur/tests/pass/trait-variant.rs
+++ b/dynosaur/tests/pass/trait-variant.rs
@@ -1,6 +1,6 @@
 #[trait_variant::make(SendNext: Send)]
-#[dynosaur::dynosaur(DynNext = dyn Next, bridge(dyn))]
-#[dynosaur::dynosaur(DynSendNext = dyn SendNext, bridge(dyn))]
+#[dynosaur::dynosaur(DynNext = dyn(box) Next, bridge(dyn))]
+#[dynosaur::dynosaur(DynSendNext = dyn(box) SendNext, bridge(dyn))]
 trait Next {
     type Item;
     async fn next(&mut self) -> Option<Self::Item>;

--- a/dynosaur/tests/pass/trait-variant.stdout
+++ b/dynosaur/tests/pass/trait-variant.stdout
@@ -74,6 +74,13 @@ mod __dynosaur_macro_dynnext {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value:
+                Box<impl Next<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynNext<'dynosaur_struct, Item>> {
+            let value: Box<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
+                value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value:
                 &(impl Next<Item = Item> + 'dynosaur_struct))
             -> &DynNext<'dynosaur_struct, Item> {
@@ -178,6 +185,14 @@ mod __dynosaur_macro_dynsendnext {
             let value:
                     std::rc::Rc<dyn ErasedSendNext<Item = Item> +
                     'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
+        pub const fn from_box(value:
+                Box<impl SendNext<Item = Item> + 'dynosaur_struct>)
+            -> Box<DynSendNext<'dynosaur_struct, Item>> {
+            let value:
+                    Box<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:

--- a/dynosaur/tests/pass/visibility.rs
+++ b/dynosaur/tests/pass/visibility.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(pub(crate) DynMyTrait = dyn(box))]
+#[dynosaur(pub(crate) DynMyTrait = dyn(box) MyTrait)]
 trait MyTrait {
     async fn foo(&self) -> i32;
 }

--- a/dynosaur/tests/pass/visibility.rs
+++ b/dynosaur/tests/pass/visibility.rs
@@ -1,6 +1,6 @@
 use dynosaur::dynosaur;
 
-#[dynosaur(pub(crate) DynMyTrait)]
+#[dynosaur(pub(crate) DynMyTrait = dyn(box))]
 trait MyTrait {
     async fn foo(&self) -> i32;
 }

--- a/dynosaur/tests/pass/visibility.stdout
+++ b/dynosaur/tests/pass/visibility.stdout
@@ -64,6 +64,11 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
+            -> Box<DynMyTrait<'dynosaur_struct>> {
+            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            unsafe { ::core::mem::transmute(value) }
+        }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -93,7 +93,9 @@ impl Parse for Bridge {
 ///
 /// ```
 /// # mod dynosaur { pub use dynosaur_derive::dynosaur; }
-/// #[dynosaur::dynosaur(pub DynNext)]
+/// use dynosaur::dynosaur;
+///
+/// #[dynosaur(pub DynNext)]
 /// pub trait Next {
 ///     type Item;
 ///     async fn next(&self) -> Option<Self::Item>;
@@ -106,7 +108,8 @@ impl Parse for Bridge {
 ///
 /// ```
 /// # mod dynosaur { pub use dynosaur_derive::dynosaur; }
-/// # #[dynosaur::dynosaur(DynNext)]
+/// # use dynosaur::dynosaur;
+/// # #[dynosaur(DynNext)]
 /// # trait Next {
 /// #     type Item;
 /// #     async fn next(&self) -> Option<Self::Item>;
@@ -174,7 +177,8 @@ impl Parse for Bridge {
 /// ```
 /// # mod dynosaur { pub use dynosaur_derive::dynosaur; }
 /// # fn main() {}
-/// #[dynosaur::dynosaur(pub DynNext, bridge(none))]
+/// # use dynosaur::dynosaur;
+/// #[dynosaur(pub DynNext, bridge(none))]
 /// pub trait Next {
 ///     type Item;
 ///     async fn next(&self) -> Option<Self::Item>;
@@ -202,9 +206,10 @@ impl Parse for Bridge {
 /// ```rust
 /// # pub mod dynosaur { pub use dynosaur_derive::dynosaur; }
 /// # fn main() {}
+/// # use dynosaur::dynosaur;
 /// #[trait_variant::make(SendNext: Send)]
-/// #[dynosaur::dynosaur(DynNext = dyn Next, bridge(dyn))]
-/// #[dynosaur::dynosaur(DynSendNext = dyn SendNext, bridge(dyn))]
+/// #[dynosaur(DynNext = dyn Next, bridge(dyn))]
+/// #[dynosaur(DynSendNext = dyn SendNext, bridge(dyn))]
 /// trait Next {
 ///     type Item;
 ///     async fn next(&mut self) -> Option<Self::Item>;
@@ -232,11 +237,12 @@ impl Parse for Bridge {
 /// ```rust
 /// # mod dynosaur { pub use dynosaur_derive::dynosaur; }
 /// # fn main() {}
+/// # use dynosaur::dynosaur;
 /// trait Foo {}
 ///
 /// impl Foo for Box<dyn Foo + '_> {}
 ///
-/// #[dynosaur::dynosaur(DynMyTrait)]
+/// #[dynosaur(DynMyTrait)]
 /// trait MyTrait {
 ///     fn foo(&self, _: impl Foo) -> i32;
 /// }

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -160,6 +160,8 @@ impl Parse for Bridge {
 ///     fn new_box(from: impl Trait) -> Box<Self> { todo!() }
 ///     fn new_arc(from: impl Trait) -> std::sync::Arc<Self> { todo!() }
 ///     fn new_rc(from: impl Trait) -> std::rc::Rc<Self> { todo!() }
+///
+///     fn from_box(from: Box<impl Trait + 'a>) -> Box<Self> { todo!() }
 ///     fn from_ref(from: &'a impl Trait) -> &'a Self { todo!() }
 ///     fn from_mut(from: &'a mut impl Trait) -> &'a mut Self { todo!() }
 /// }
@@ -500,6 +502,11 @@ fn mk_struct_inherent_impl(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
             pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> std::rc::Rc<#struct_ident #struct_params> {
                 let value = std::rc::Rc::new(value);
                 let value: std::rc::Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+                unsafe { ::core::mem::transmute(value) }
+            }
+
+            pub const fn from_box(value: Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> Box<#struct_ident #struct_params> {
+                let value: Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 


### PR DESCRIPTION
Best reviewed one commit at a time.

The most controversial change here is to require `= dyn(box)` syntax, which leaves room for future strategies that don't involve boxing. This makes it clear to the user that they are opting into a boxing strategy for the Dyn type, which can help them decide if they want to make it public.

One nice thing about this is that we can add back the `from_box` constructor (formerly `new`). `from_box`, `from_ref`, and `from_mut` all rely on a strategy that does not embed storage on the stack, i.e. one that always boxes. We shouldn't remove `from_ref` and `from_mut` without some alternative API, and designing that (#90) will take some trial and error. So we might as well give people all the benefits of using a boxing strategy.

I considered also renaming the `from_*` constructors to `cast_*` to leave room for a more flexible API that works with non-boxing strategies. But that seemed disruptive and I couldn't convince myself that "cast" was a good name. We can reuse the same names and just change the API when the strategy changes. There should always be a way to write code that works with both, though it's not clear why you would.