### PR TITLE
Generate documentation for DynTrait wrappers

### DIFF
--- a/dynosaur/examples/pub_trait.rs
+++ b/dynosaur/examples/pub_trait.rs
@@ -1,0 +1,17 @@
+//! Example demonstrating using dynosaur in a library crate with `#![missing_docs]`.
+
+// Deny missing docs to prove that documentation is generated for DynMyTrait.
+#![deny(missing_docs)]
+
+use std::future::Future;
+
+use dynosaur::dynosaur;
+
+/// A simple trait to test lint compatibility.
+#[dynosaur(pub DynMyTrait = dyn(box) MyTrait)]
+pub trait MyTrait {
+    /// A simple method to test lint compatability.
+    fn foo(&self) -> impl Future<Output = i32>;
+}
+
+fn main() {}

--- a/dynosaur/tests/fail/const-attr.stdout
+++ b/dynosaur/tests/fail/const-attr.stdout
@@ -29,6 +29,7 @@ mod __dynosaur_macro_dynfoo {
             _Box::new(<Self as Foo>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Foo`]."]
     #[repr(transparent)]
     pub struct DynFoo<'dynosaur_struct> {
         ptr: dyn ErasedFoo + 'dynosaur_struct,
@@ -42,44 +43,52 @@ mod __dynosaur_macro_dynfoo {
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
+        #[doc = "Create `Box<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
             -> _Box<DynFoo<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
             -> _Arc<DynFoo<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
             -> _Rc<DynFoo<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Foo>` to `Box<DynFoo>`."]
         pub const fn from_box(value: _Box<impl Foo + 'dynosaur_struct>)
             -> _Box<DynFoo<'dynosaur_struct>> {
             let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Foo>` to `Arc<DynFoo>`."]
         pub const fn from_arc(value: _Arc<impl Foo + 'dynosaur_struct>)
             -> _Arc<DynFoo<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Foo>` to `Rc<DynFoo>`."]
         pub const fn from_rc(value: _Rc<impl Foo + 'dynosaur_struct>)
             -> _Rc<DynFoo<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Foo` to `&DynFoo`."]
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct> {
             let value: &(dyn ErasedFoo + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Foo` to `&mut DynFoo`."]
         pub const fn from_mut(value: &mut (impl Foo + 'dynosaur_struct))
             -> &mut DynFoo<'dynosaur_struct> {
             let value: &mut (dyn ErasedFoo + 'dynosaur_struct) = &mut *value;

--- a/dynosaur/tests/fail/self_and_box_receivers.stdout
+++ b/dynosaur/tests/fail/self_and_box_receivers.stdout
@@ -61,6 +61,7 @@ mod __dynosaur_macro_dynall {
             _Box::new(<Self as All>::self_rc(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`All`]."]
     #[repr(transparent)]
     pub struct DynAll<'dynosaur_struct> {
         ptr: dyn ErasedAll + 'dynosaur_struct,
@@ -93,44 +94,52 @@ mod __dynosaur_macro_dynall {
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
+        #[doc = "Create `Box<DynAll>` from a value implementing [`All`]."]
         pub fn new_box(value: impl All + 'dynosaur_struct)
             -> _Box<DynAll<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynAll>` from a value implementing [`All`]."]
         pub fn new_arc(value: impl All + 'dynosaur_struct)
             -> _Arc<DynAll<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynAll>` from a value implementing [`All`]."]
         pub fn new_rc(value: impl All + 'dynosaur_struct)
             -> _Rc<DynAll<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl All>` to `Box<DynAll>`."]
         pub const fn from_box(value: _Box<impl All + 'dynosaur_struct>)
             -> _Box<DynAll<'dynosaur_struct>> {
             let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl All>` to `Arc<DynAll>`."]
         pub const fn from_arc(value: _Arc<impl All + 'dynosaur_struct>)
             -> _Arc<DynAll<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl All>` to `Rc<DynAll>`."]
         pub const fn from_rc(value: _Rc<impl All + 'dynosaur_struct>)
             -> _Rc<DynAll<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl All` to `&DynAll`."]
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))
             -> &DynAll<'dynosaur_struct> {
             let value: &(dyn ErasedAll + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl All` to `&mut DynAll`."]
         pub const fn from_mut(value: &mut (impl All + 'dynosaur_struct))
             -> &mut DynAll<'dynosaur_struct> {
             let value: &mut (dyn ErasedAll + 'dynosaur_struct) = &mut *value;

--- a/dynosaur/tests/fail/where-self-sized-rpit.stdout
+++ b/dynosaur/tests/fail/where-self-sized-rpit.stdout
@@ -25,6 +25,7 @@ mod __dynosaur_macro_dynmytrait {
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -50,44 +51,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/fail/where-self-sized.stdout
+++ b/dynosaur/tests/fail/where-self-sized.stdout
@@ -24,6 +24,7 @@ mod __dynosaur_macro_dynmytrait {
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -44,44 +45,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/anynomous-args.stdout
+++ b/dynosaur/tests/pass/anynomous-args.stdout
@@ -35,6 +35,7 @@ mod __dynosaur_macro_dynsometrait {
                     __dynosaur_arg2))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`SomeTrait`]."]
     #[repr(transparent)]
     pub struct DynSomeTrait<'dynosaur_struct> {
         ptr: dyn ErasedSomeTrait + 'dynosaur_struct,
@@ -54,44 +55,55 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl SomeTrait>` to `Box<DynSomeTrait>`."]
         pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl SomeTrait>` to `Arc<DynSomeTrait>`."]
         pub const fn from_arc(value: _Arc<impl SomeTrait + 'dynosaur_struct>)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl SomeTrait>` to `Rc<DynSomeTrait>`."]
         pub const fn from_rc(value: _Rc<impl SomeTrait + 'dynosaur_struct>)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl SomeTrait` to `&DynSomeTrait`."]
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl SomeTrait` to `&mut DynSomeTrait`."]
         pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/associated-types.stdout
+++ b/dynosaur/tests/pass/associated-types.stdout
@@ -36,6 +36,7 @@ mod __dynosaur_macro_dynfoo {
             _Box::pin(<Self as Foo>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Foo`]."]
     #[repr(transparent)]
     pub struct DynFoo<'dynosaur_struct, Bar: Baz> {
         ptr: dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct,
@@ -53,6 +54,7 @@ mod __dynosaur_macro_dynfoo {
         }
     }
     impl<'dynosaur_struct, Bar: Baz> DynFoo<'dynosaur_struct, Bar> {
+        #[doc = "Create `Box<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_box(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
             -> _Box<DynFoo<'dynosaur_struct, Bar>> {
             let value = _Box::new(value);
@@ -60,6 +62,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_arc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
             -> _Arc<DynFoo<'dynosaur_struct, Bar>> {
             let value = _Arc::new(value);
@@ -67,6 +70,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_rc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
             -> _Rc<DynFoo<'dynosaur_struct, Bar>> {
             let value = _Rc::new(value);
@@ -74,6 +78,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Foo>` to `Box<DynFoo>`."]
         pub const fn from_box(value:
                 _Box<impl Foo<Bar = Bar> + 'dynosaur_struct>)
             -> _Box<DynFoo<'dynosaur_struct, Bar>> {
@@ -81,6 +86,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Foo>` to `Arc<DynFoo>`."]
         pub const fn from_arc(value:
                 _Arc<impl Foo<Bar = Bar> + 'dynosaur_struct>)
             -> _Arc<DynFoo<'dynosaur_struct, Bar>> {
@@ -88,6 +94,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Foo>` to `Rc<DynFoo>`."]
         pub const fn from_rc(value:
                 _Rc<impl Foo<Bar = Bar> + 'dynosaur_struct>)
             -> _Rc<DynFoo<'dynosaur_struct, Bar>> {
@@ -95,6 +102,7 @@ mod __dynosaur_macro_dynfoo {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Foo` to `&DynFoo`."]
         pub const fn from_ref(value:
                 &(impl Foo<Bar = Bar> + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct, Bar> {
@@ -102,6 +110,7 @@ mod __dynosaur_macro_dynfoo {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Foo` to `&mut DynFoo`."]
         pub const fn from_mut(value:
                 &mut (impl Foo<Bar = Bar> + 'dynosaur_struct))
             -> &mut DynFoo<'dynosaur_struct, Bar> {

--- a/dynosaur/tests/pass/async-and-non-async.stdout
+++ b/dynosaur/tests/pass/async-and-non-async.stdout
@@ -33,6 +33,7 @@ mod __dynosaur_macro_dynjobqueue {
             _Box::pin(<Self as JobQueue>::dispatch(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`JobQueue`]."]
     #[repr(transparent)]
     pub struct DynJobQueue<'dynosaur_struct> {
         ptr: dyn ErasedJobQueue + 'dynosaur_struct,
@@ -50,44 +51,55 @@ mod __dynosaur_macro_dynjobqueue {
         }
     }
     impl<'dynosaur_struct> DynJobQueue<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynJobQueue>` from a value implementing [`JobQueue`]."]
         pub fn new_box(value: impl JobQueue + 'dynosaur_struct)
             -> _Box<DynJobQueue<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynJobQueue>` from a value implementing [`JobQueue`]."]
         pub fn new_arc(value: impl JobQueue + 'dynosaur_struct)
             -> _Arc<DynJobQueue<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynJobQueue>` from a value implementing [`JobQueue`]."]
         pub fn new_rc(value: impl JobQueue + 'dynosaur_struct)
             -> _Rc<DynJobQueue<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl JobQueue>` to `Box<DynJobQueue>`."]
         pub const fn from_box(value: _Box<impl JobQueue + 'dynosaur_struct>)
             -> _Box<DynJobQueue<'dynosaur_struct>> {
             let value: _Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl JobQueue>` to `Arc<DynJobQueue>`."]
         pub const fn from_arc(value: _Arc<impl JobQueue + 'dynosaur_struct>)
             -> _Arc<DynJobQueue<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl JobQueue>` to `Rc<DynJobQueue>`."]
         pub const fn from_rc(value: _Rc<impl JobQueue + 'dynosaur_struct>)
             -> _Rc<DynJobQueue<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl JobQueue` to `&DynJobQueue`."]
         pub const fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
             -> &DynJobQueue<'dynosaur_struct> {
             let value: &(dyn ErasedJobQueue + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl JobQueue` to `&mut DynJobQueue`."]
         pub const fn from_mut(value: &mut (impl JobQueue + 'dynosaur_struct))
             -> &mut DynJobQueue<'dynosaur_struct> {
             let value: &mut (dyn ErasedJobQueue + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/basic-apit.stdout
+++ b/dynosaur/tests/pass/basic-apit.stdout
@@ -55,6 +55,7 @@ mod __dynosaur_macro_dynmytrait {
             <Self as MyTrait>::baz(self, __dynosaur_arg1)
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -78,44 +79,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/basic-mut.stdout
+++ b/dynosaur/tests/pass/basic-mut.stdout
@@ -28,6 +28,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -44,44 +45,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/basic-no-ret.stdout
+++ b/dynosaur/tests/pass/basic-no-ret.stdout
@@ -28,6 +28,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -44,44 +45,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/basic-rpitit.stdout
+++ b/dynosaur/tests/pass/basic-rpitit.stdout
@@ -28,6 +28,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::new(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -41,44 +42,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/basic-with-self.stdout
+++ b/dynosaur/tests/pass/basic-with-self.stdout
@@ -35,6 +35,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct, Item> {
         ptr: dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct,
@@ -53,6 +54,8 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -61,6 +64,8 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -69,6 +74,8 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -77,6 +84,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value:
                 _Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
@@ -85,6 +93,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value:
                 _Arc<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
@@ -93,6 +102,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value:
                 _Rc<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
@@ -101,6 +111,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {
@@ -108,6 +119,7 @@ mod __dynosaur_macro_dynmytrait {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value:
                 &mut (impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/basic.stdout
+++ b/dynosaur/tests/pass/basic.stdout
@@ -30,6 +30,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -46,44 +47,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/bridge-attr.stdout
+++ b/dynosaur/tests/pass/bridge-attr.stdout
@@ -34,6 +34,7 @@ mod __dynosaur_macro_dynnextnone {
             _Box::pin(<Self as NextNone>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`NextNone`]."]
     #[repr(transparent)]
     pub struct DynNextNone<'dynosaur_struct, Item> {
         ptr: dyn ErasedNextNone<Item = Item> + 'dynosaur_struct,
@@ -54,6 +55,8 @@ mod __dynosaur_macro_dynnextnone {
         }
     }
     impl<'dynosaur_struct, Item> DynNextNone<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynNextNone>` from a value implementing [`NextNone`]."]
         pub fn new_box(value: impl NextNone<Item = Item> + 'dynosaur_struct)
             -> _Box<DynNextNone<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -62,6 +65,8 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynNextNone>` from a value implementing [`NextNone`]."]
         pub fn new_arc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynNextNone<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -70,6 +75,8 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynNextNone>` from a value implementing [`NextNone`]."]
         pub fn new_rc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynNextNone<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -78,6 +85,7 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl NextNone>` to `Box<DynNextNone>`."]
         pub const fn from_box(value:
                 _Box<impl NextNone<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynNextNone<'dynosaur_struct, Item>> {
@@ -86,6 +94,7 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl NextNone>` to `Arc<DynNextNone>`."]
         pub const fn from_arc(value:
                 _Arc<impl NextNone<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynNextNone<'dynosaur_struct, Item>> {
@@ -94,6 +103,7 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl NextNone>` to `Rc<DynNextNone>`."]
         pub const fn from_rc(value:
                 _Rc<impl NextNone<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynNextNone<'dynosaur_struct, Item>> {
@@ -102,6 +112,7 @@ mod __dynosaur_macro_dynnextnone {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl NextNone` to `&DynNextNone`."]
         pub const fn from_ref(value:
                 &(impl NextNone<Item = Item> + 'dynosaur_struct))
             -> &DynNextNone<'dynosaur_struct, Item> {
@@ -109,6 +120,7 @@ mod __dynosaur_macro_dynnextnone {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl NextNone` to `&mut DynNextNone`."]
         pub const fn from_mut(value:
                 &mut (impl NextNone<Item = Item> + 'dynosaur_struct))
             -> &mut DynNextNone<'dynosaur_struct, Item> {
@@ -153,6 +165,7 @@ mod __dynosaur_macro_dynnextdefault {
             _Box::pin(<Self as NextDefault>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`NextDefault`]."]
     #[repr(transparent)]
     pub struct DynNextDefault<'dynosaur_struct, Item> {
         ptr: dyn ErasedNextDefault<Item = Item> + 'dynosaur_struct,
@@ -173,6 +186,8 @@ mod __dynosaur_macro_dynnextdefault {
         }
     }
     impl<'dynosaur_struct, Item> DynNextDefault<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynNextDefault>` from a value implementing [`NextDefault`]."]
         pub fn new_box(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
             -> _Box<DynNextDefault<'dynosaur_struct, Item>> {
@@ -182,6 +197,8 @@ mod __dynosaur_macro_dynnextdefault {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynNextDefault>` from a value implementing [`NextDefault`]."]
         pub fn new_arc(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynNextDefault<'dynosaur_struct, Item>> {
@@ -191,6 +208,8 @@ mod __dynosaur_macro_dynnextdefault {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynNextDefault>` from a value implementing [`NextDefault`]."]
         pub fn new_rc(value: impl NextDefault<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynNextDefault<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -199,6 +218,7 @@ mod __dynosaur_macro_dynnextdefault {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl NextDefault>` to `Box<DynNextDefault>`."]
         pub const fn from_box(value:
                 _Box<impl NextDefault<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynNextDefault<'dynosaur_struct, Item>> {
@@ -207,6 +227,7 @@ mod __dynosaur_macro_dynnextdefault {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl NextDefault>` to `Arc<DynNextDefault>`."]
         pub const fn from_arc(value:
                 _Arc<impl NextDefault<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynNextDefault<'dynosaur_struct, Item>> {
@@ -215,6 +236,7 @@ mod __dynosaur_macro_dynnextdefault {
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl NextDefault>` to `Rc<DynNextDefault>`."]
         pub const fn from_rc(value:
                 _Rc<impl NextDefault<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynNextDefault<'dynosaur_struct, Item>> {
@@ -223,6 +245,7 @@ mod __dynosaur_macro_dynnextdefault {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl NextDefault` to `&DynNextDefault`."]
         pub const fn from_ref(value:
                 &(impl NextDefault<Item = Item> + 'dynosaur_struct))
             -> &DynNextDefault<'dynosaur_struct, Item> {
@@ -231,6 +254,7 @@ mod __dynosaur_macro_dynnextdefault {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl NextDefault` to `&mut DynNextDefault`."]
         pub const fn from_mut(value:
                 &mut (impl NextDefault<Item = Item> + 'dynosaur_struct))
             -> &mut DynNextDefault<'dynosaur_struct, Item> {
@@ -291,6 +315,7 @@ mod __dynosaur_macro_dynnextdyn {
             _Box::pin(<Self as NextDyn>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`NextDyn`]."]
     #[repr(transparent)]
     pub struct DynNextDyn<'dynosaur_struct, Item> {
         ptr: dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct,
@@ -311,6 +336,8 @@ mod __dynosaur_macro_dynnextdyn {
         }
     }
     impl<'dynosaur_struct, Item> DynNextDyn<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynNextDyn>` from a value implementing [`NextDyn`]."]
         pub fn new_box(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
             -> _Box<DynNextDyn<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -319,6 +346,8 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynNextDyn>` from a value implementing [`NextDyn`]."]
         pub fn new_arc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynNextDyn<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -327,6 +356,8 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynNextDyn>` from a value implementing [`NextDyn`]."]
         pub fn new_rc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynNextDyn<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -335,6 +366,7 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl NextDyn>` to `Box<DynNextDyn>`."]
         pub const fn from_box(value:
                 _Box<impl NextDyn<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynNextDyn<'dynosaur_struct, Item>> {
@@ -343,6 +375,7 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl NextDyn>` to `Arc<DynNextDyn>`."]
         pub const fn from_arc(value:
                 _Arc<impl NextDyn<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynNextDyn<'dynosaur_struct, Item>> {
@@ -351,6 +384,7 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl NextDyn>` to `Rc<DynNextDyn>`."]
         pub const fn from_rc(value:
                 _Rc<impl NextDyn<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynNextDyn<'dynosaur_struct, Item>> {
@@ -359,6 +393,7 @@ mod __dynosaur_macro_dynnextdyn {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl NextDyn` to `&DynNextDyn`."]
         pub const fn from_ref(value:
                 &(impl NextDyn<Item = Item> + 'dynosaur_struct))
             -> &DynNextDyn<'dynosaur_struct, Item> {
@@ -366,6 +401,7 @@ mod __dynosaur_macro_dynnextdyn {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl NextDyn` to `&mut DynNextDyn`."]
         pub const fn from_mut(value:
                 &mut (impl NextDyn<Item = Item> + 'dynosaur_struct))
             -> &mut DynNextDyn<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/default-method-trait.stdout
+++ b/dynosaur/tests/pass/default-method-trait.stdout
@@ -28,6 +28,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::new(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -41,44 +42,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/generics-in-trait-def.stdout
+++ b/dynosaur/tests/pass/generics-in-trait-def.stdout
@@ -42,6 +42,7 @@ mod __dynosaur_macro_dynservice {
             _Box::pin(<Self as Service<Request>>::call(self, req))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Service`]."]
     #[repr(transparent)]
     pub struct DynService<'dynosaur_struct, Request, Response, Error> {
         ptr: dyn ErasedService<Request, Response = Response, Error = Error> +
@@ -66,6 +67,8 @@ mod __dynosaur_macro_dynservice {
     }
     impl<'dynosaur_struct, Request, Response, Error>
         DynService<'dynosaur_struct, Request, Response, Error> {
+        #[doc =
+        "Create `Box<DynService>` from a value implementing [`Service`]."]
         pub fn new_box(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
@@ -76,6 +79,8 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynService>` from a value implementing [`Service`]."]
         pub fn new_arc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
@@ -86,6 +91,8 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynService>` from a value implementing [`Service`]."]
         pub fn new_rc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
@@ -96,6 +103,7 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Service>` to `Box<DynService>`."]
         pub const fn from_box(value:
                 _Box<impl Service<Request, Response = Response, Error =
                 Error> + 'dynosaur_struct>)
@@ -105,6 +113,7 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Service>` to `Arc<DynService>`."]
         pub const fn from_arc(value:
                 _Arc<impl Service<Request, Response = Response, Error =
                 Error> + 'dynosaur_struct>)
@@ -114,6 +123,7 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Service>` to `Rc<DynService>`."]
         pub const fn from_rc(value:
                 _Rc<impl Service<Request, Response = Response, Error =
                 Error> + 'dynosaur_struct>)
@@ -123,6 +133,7 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Service` to `&DynService`."]
         pub const fn from_ref(value:
                 &(impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct))
@@ -132,6 +143,7 @@ mod __dynosaur_macro_dynservice {
                     Error> + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Service` to `&mut DynService`."]
         pub const fn from_mut(value:
                 &mut (impl Service<Request, Response = Response, Error =
                 Error> + 'dynosaur_struct))

--- a/dynosaur/tests/pass/handle-lifetimes.stdout
+++ b/dynosaur/tests/pass/handle-lifetimes.stdout
@@ -35,6 +35,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self, x))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct, Item> {
         ptr: dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct,
@@ -53,6 +54,8 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -61,6 +64,8 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -69,6 +74,8 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -77,6 +84,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value:
                 _Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
@@ -85,6 +93,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value:
                 _Arc<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
@@ -93,6 +102,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value:
                 _Rc<impl MyTrait<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
@@ -101,6 +111,7 @@ mod __dynosaur_macro_dynmytrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value:
                 &(impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct, Item> {
@@ -108,6 +119,7 @@ mod __dynosaur_macro_dynmytrait {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value:
                 &mut (impl MyTrait<Item = Item> + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/impl-future-bounds.stdout
+++ b/dynosaur/tests/pass/impl-future-bounds.stdout
@@ -29,6 +29,7 @@ mod __dynosaur_macro_dynfoo {
             _Box::pin(<Self as Foo>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Foo`]."]
     #[repr(transparent)]
     pub struct DynFoo<'dynosaur_struct> {
         ptr: dyn ErasedFoo + 'dynosaur_struct,
@@ -43,44 +44,52 @@ mod __dynosaur_macro_dynfoo {
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
+        #[doc = "Create `Box<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
             -> _Box<DynFoo<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
             -> _Arc<DynFoo<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynFoo>` from a value implementing [`Foo`]."]
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
             -> _Rc<DynFoo<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Foo>` to `Box<DynFoo>`."]
         pub const fn from_box(value: _Box<impl Foo + 'dynosaur_struct>)
             -> _Box<DynFoo<'dynosaur_struct>> {
             let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Foo>` to `Arc<DynFoo>`."]
         pub const fn from_arc(value: _Arc<impl Foo + 'dynosaur_struct>)
             -> _Arc<DynFoo<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Foo>` to `Rc<DynFoo>`."]
         pub const fn from_rc(value: _Rc<impl Foo + 'dynosaur_struct>)
             -> _Rc<DynFoo<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Foo` to `&DynFoo`."]
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
             -> &DynFoo<'dynosaur_struct> {
             let value: &(dyn ErasedFoo + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Foo` to `&mut DynFoo`."]
         pub const fn from_mut(value: &mut (impl Foo + 'dynosaur_struct))
             -> &mut DynFoo<'dynosaur_struct> {
             let value: &mut (dyn ErasedFoo + 'dynosaur_struct) = &mut *value;

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
@@ -45,6 +45,7 @@ mod __dynosaur_macro_dynsometrait {
                         SomeTrait<'a, 'b>>::lotsa_lifetimes(self, a, b, c))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`SomeTrait`]."]
     #[repr(transparent)]
     pub struct DynSomeTrait<'dynosaur_struct, 'a, 'b> {
         ptr: dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct,
@@ -64,6 +65,8 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'dynosaur_struct, 'a, 'b> DynSomeTrait<'dynosaur_struct, 'a, 'b> {
+        #[doc =
+        "Create `Box<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_box(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
             -> _Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
             let value = _Box::new(value);
@@ -71,6 +74,8 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_arc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
             -> _Arc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
             let value = _Arc::new(value);
@@ -78,6 +83,8 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_rc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
             -> _Rc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
             let value = _Rc::new(value);
@@ -85,6 +92,7 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl SomeTrait>` to `Box<DynSomeTrait>`."]
         pub const fn from_box(value:
                 _Box<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
             -> _Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
@@ -92,6 +100,7 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl SomeTrait>` to `Arc<DynSomeTrait>`."]
         pub const fn from_arc(value:
                 _Arc<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
             -> _Arc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
@@ -99,6 +108,7 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl SomeTrait>` to `Rc<DynSomeTrait>`."]
         pub const fn from_rc(value:
                 _Rc<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
             -> _Rc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
@@ -106,6 +116,7 @@ mod __dynosaur_macro_dynsometrait {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl SomeTrait` to `&DynSomeTrait`."]
         pub const fn from_ref(value:
                 &(impl SomeTrait<'a, 'b> + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct, 'a, 'b> {
@@ -113,6 +124,7 @@ mod __dynosaur_macro_dynsometrait {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl SomeTrait` to `&mut DynSomeTrait`."]
         pub const fn from_mut(value:
                 &mut (impl SomeTrait<'a, 'b> + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct, 'a, 'b> {

--- a/dynosaur/tests/pass/multiple-lifetimes.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes.stdout
@@ -90,6 +90,7 @@ mod __dynosaur_macro_dynsometrait {
                         SomeTrait>::multiple_static_and_anonymous(self, a, b, c))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`SomeTrait`]."]
     #[repr(transparent)]
     pub struct DynSomeTrait<'dynosaur_struct> {
         ptr: dyn ErasedSomeTrait + 'dynosaur_struct,
@@ -138,44 +139,55 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl SomeTrait>` to `Box<DynSomeTrait>`."]
         pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl SomeTrait>` to `Arc<DynSomeTrait>`."]
         pub const fn from_arc(value: _Arc<impl SomeTrait + 'dynosaur_struct>)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl SomeTrait>` to `Rc<DynSomeTrait>`."]
         pub const fn from_rc(value: _Rc<impl SomeTrait + 'dynosaur_struct>)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl SomeTrait` to `&DynSomeTrait`."]
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl SomeTrait` to `&mut DynSomeTrait`."]
         pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/non-future-impl-traits.stdout
+++ b/dynosaur/tests/pass/non-future-impl-traits.stdout
@@ -27,6 +27,7 @@ mod __dynosaur_macro_dynsometrait {
             _Box::new(<Self as SomeTrait>::get_iter(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`SomeTrait`]."]
     #[repr(transparent)]
     pub struct DynSomeTrait<'dynosaur_struct> {
         ptr: dyn ErasedSomeTrait + 'dynosaur_struct,
@@ -40,44 +41,55 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynSomeTrait>` from a value implementing [`SomeTrait`]."]
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl SomeTrait>` to `Box<DynSomeTrait>`."]
         pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
             -> _Box<DynSomeTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl SomeTrait>` to `Arc<DynSomeTrait>`."]
         pub const fn from_arc(value: _Arc<impl SomeTrait + 'dynosaur_struct>)
             -> _Arc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl SomeTrait>` to `Rc<DynSomeTrait>`."]
         pub const fn from_rc(value: _Rc<impl SomeTrait + 'dynosaur_struct>)
             -> _Rc<DynSomeTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl SomeTrait` to `&DynSomeTrait`."]
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
             -> &DynSomeTrait<'dynosaur_struct> {
             let value: &(dyn ErasedSomeTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl SomeTrait` to `&mut DynSomeTrait`."]
         pub const fn from_mut(value: &mut (impl SomeTrait + 'dynosaur_struct))
             -> &mut DynSomeTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedSomeTrait + 'dynosaur_struct) =

--- a/dynosaur/tests/pass/readme-example.stdout
+++ b/dynosaur/tests/pass/readme-example.stdout
@@ -36,6 +36,7 @@ mod __dynosaur_macro_dynnext {
             _Box::pin(<Self as Next>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Next`]."]
     #[repr(transparent)]
     pub struct DynNext<'dynosaur_struct, Item> {
         ptr: dyn ErasedNext<Item = Item> + 'dynosaur_struct,
@@ -55,6 +56,7 @@ mod __dynosaur_macro_dynnext {
         }
     }
     impl<'dynosaur_struct, Item> DynNext<'dynosaur_struct, Item> {
+        #[doc = "Create `Box<DynNext>` from a value implementing [`Next`]."]
         pub fn new_box(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Box<DynNext<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -62,6 +64,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynNext>` from a value implementing [`Next`]."]
         pub fn new_arc(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynNext<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -69,6 +72,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynNext>` from a value implementing [`Next`]."]
         pub fn new_rc(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynNext<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -76,6 +80,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Next>` to `Box<DynNext>`."]
         pub const fn from_box(value:
                 _Box<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynNext<'dynosaur_struct, Item>> {
@@ -83,6 +88,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Next>` to `Arc<DynNext>`."]
         pub const fn from_arc(value:
                 _Arc<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynNext<'dynosaur_struct, Item>> {
@@ -90,6 +96,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Next>` to `Rc<DynNext>`."]
         pub const fn from_rc(value:
                 _Rc<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynNext<'dynosaur_struct, Item>> {
@@ -97,6 +104,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Next` to `&DynNext`."]
         pub const fn from_ref(value:
                 &(impl Next<Item = Item> + 'dynosaur_struct))
             -> &DynNext<'dynosaur_struct, Item> {
@@ -104,6 +112,7 @@ mod __dynosaur_macro_dynnext {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Next` to `&mut DynNext`."]
         pub const fn from_mut(value:
                 &mut (impl Next<Item = Item> + 'dynosaur_struct))
             -> &mut DynNext<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
@@ -18,6 +18,7 @@ mod __dynosaur_macro_dynrefonly {
     impl<DYNOSAUR: RefOnly> ErasedRefOnly for DYNOSAUR {
         fn ref_(&self) { <Self as RefOnly>::ref_(self) }
     }
+    #[doc = "Dyn-compatible wrapper for [`RefOnly`]."]
     #[repr(transparent)]
     pub struct DynRefOnly<'dynosaur_struct> {
         ptr: dyn ErasedRefOnly + 'dynosaur_struct,
@@ -26,44 +27,55 @@ mod __dynosaur_macro_dynrefonly {
         fn ref_(&self) { self.ptr.ref_() }
     }
     impl<'dynosaur_struct> DynRefOnly<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynRefOnly>` from a value implementing [`RefOnly`]."]
         pub fn new_box(value: impl RefOnly + 'dynosaur_struct)
             -> _Box<DynRefOnly<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynRefOnly>` from a value implementing [`RefOnly`]."]
         pub fn new_arc(value: impl RefOnly + 'dynosaur_struct)
             -> _Arc<DynRefOnly<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynRefOnly>` from a value implementing [`RefOnly`]."]
         pub fn new_rc(value: impl RefOnly + 'dynosaur_struct)
             -> _Rc<DynRefOnly<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl RefOnly>` to `Box<DynRefOnly>`."]
         pub const fn from_box(value: _Box<impl RefOnly + 'dynosaur_struct>)
             -> _Box<DynRefOnly<'dynosaur_struct>> {
             let value: _Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl RefOnly>` to `Arc<DynRefOnly>`."]
         pub const fn from_arc(value: _Arc<impl RefOnly + 'dynosaur_struct>)
             -> _Arc<DynRefOnly<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl RefOnly>` to `Rc<DynRefOnly>`."]
         pub const fn from_rc(value: _Rc<impl RefOnly + 'dynosaur_struct>)
             -> _Rc<DynRefOnly<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl RefOnly` to `&DynRefOnly`."]
         pub const fn from_ref(value: &(impl RefOnly + 'dynosaur_struct))
             -> &DynRefOnly<'dynosaur_struct> {
             let value: &(dyn ErasedRefOnly + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl RefOnly` to `&mut DynRefOnly`."]
         pub const fn from_mut(value: &mut (impl RefOnly + 'dynosaur_struct))
             -> &mut DynRefOnly<'dynosaur_struct> {
             let value: &mut (dyn ErasedRefOnly + 'dynosaur_struct) =
@@ -111,6 +123,7 @@ mod __dynosaur_macro_dynmutandref {
             _Box::new(<Self as MutAndRef>::ref_(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MutAndRef`]."]
     #[repr(transparent)]
     pub struct DynMutAndRef<'dynosaur_struct> {
         ptr: dyn ErasedMutAndRef + 'dynosaur_struct,
@@ -125,44 +138,55 @@ mod __dynosaur_macro_dynmutandref {
         }
     }
     impl<'dynosaur_struct> DynMutAndRef<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMutAndRef>` from a value implementing [`MutAndRef`]."]
         pub fn new_box(value: impl MutAndRef + 'dynosaur_struct)
             -> _Box<DynMutAndRef<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMutAndRef>` from a value implementing [`MutAndRef`]."]
         pub fn new_arc(value: impl MutAndRef + 'dynosaur_struct)
             -> _Arc<DynMutAndRef<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMutAndRef>` from a value implementing [`MutAndRef`]."]
         pub fn new_rc(value: impl MutAndRef + 'dynosaur_struct)
             -> _Rc<DynMutAndRef<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MutAndRef>` to `Box<DynMutAndRef>`."]
         pub const fn from_box(value: _Box<impl MutAndRef + 'dynosaur_struct>)
             -> _Box<DynMutAndRef<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MutAndRef>` to `Arc<DynMutAndRef>`."]
         pub const fn from_arc(value: _Arc<impl MutAndRef + 'dynosaur_struct>)
             -> _Arc<DynMutAndRef<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MutAndRef>` to `Rc<DynMutAndRef>`."]
         pub const fn from_rc(value: _Rc<impl MutAndRef + 'dynosaur_struct>)
             -> _Rc<DynMutAndRef<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MutAndRef` to `&DynMutAndRef`."]
         pub const fn from_ref(value: &(impl MutAndRef + 'dynosaur_struct))
             -> &DynMutAndRef<'dynosaur_struct> {
             let value: &(dyn ErasedMutAndRef + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MutAndRef` to `&mut DynMutAndRef`."]
         pub const fn from_mut(value: &mut (impl MutAndRef + 'dynosaur_struct))
             -> &mut DynMutAndRef<'dynosaur_struct> {
             let value: &mut (dyn ErasedMutAndRef + 'dynosaur_struct) =
@@ -212,6 +236,7 @@ mod __dynosaur_macro_dynall {
             _Box::new(<Self as All>::ref_(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`All`]."]
     #[repr(transparent)]
     pub struct DynAll<'dynosaur_struct> {
         ptr: dyn ErasedAll + 'dynosaur_struct,
@@ -226,44 +251,52 @@ mod __dynosaur_macro_dynall {
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
+        #[doc = "Create `Box<DynAll>` from a value implementing [`All`]."]
         pub fn new_box(value: impl All + 'dynosaur_struct)
             -> _Box<DynAll<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynAll>` from a value implementing [`All`]."]
         pub fn new_arc(value: impl All + 'dynosaur_struct)
             -> _Arc<DynAll<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynAll>` from a value implementing [`All`]."]
         pub fn new_rc(value: impl All + 'dynosaur_struct)
             -> _Rc<DynAll<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl All>` to `Box<DynAll>`."]
         pub const fn from_box(value: _Box<impl All + 'dynosaur_struct>)
             -> _Box<DynAll<'dynosaur_struct>> {
             let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl All>` to `Arc<DynAll>`."]
         pub const fn from_arc(value: _Arc<impl All + 'dynosaur_struct>)
             -> _Arc<DynAll<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl All>` to `Rc<DynAll>`."]
         pub const fn from_rc(value: _Rc<impl All + 'dynosaur_struct>)
             -> _Rc<DynAll<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl All` to `&DynAll`."]
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))
             -> &DynAll<'dynosaur_struct> {
             let value: &(dyn ErasedAll + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl All` to `&mut DynAll`."]
         pub const fn from_mut(value: &mut (impl All + 'dynosaur_struct))
             -> &mut DynAll<'dynosaur_struct> {
             let value: &mut (dyn ErasedAll + 'dynosaur_struct) = &mut *value;

--- a/dynosaur/tests/pass/trait-variant.stdout
+++ b/dynosaur/tests/pass/trait-variant.stdout
@@ -36,6 +36,7 @@ mod __dynosaur_macro_dynnext {
             _Box::pin(<Self as Next>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`Next`]."]
     #[repr(transparent)]
     pub struct DynNext<'dynosaur_struct, Item> {
         ptr: dyn ErasedNext<Item = Item> + 'dynosaur_struct,
@@ -55,6 +56,7 @@ mod __dynosaur_macro_dynnext {
         }
     }
     impl<'dynosaur_struct, Item> DynNext<'dynosaur_struct, Item> {
+        #[doc = "Create `Box<DynNext>` from a value implementing [`Next`]."]
         pub fn new_box(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Box<DynNext<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -62,6 +64,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Arc<DynNext>` from a value implementing [`Next`]."]
         pub fn new_arc(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynNext<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -69,6 +72,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Create `Rc<DynNext>` from a value implementing [`Next`]."]
         pub fn new_rc(value: impl Next<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynNext<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -76,6 +80,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl Next>` to `Box<DynNext>`."]
         pub const fn from_box(value:
                 _Box<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynNext<'dynosaur_struct, Item>> {
@@ -83,6 +88,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl Next>` to `Arc<DynNext>`."]
         pub const fn from_arc(value:
                 _Arc<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynNext<'dynosaur_struct, Item>> {
@@ -90,6 +96,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl Next>` to `Rc<DynNext>`."]
         pub const fn from_rc(value:
                 _Rc<impl Next<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynNext<'dynosaur_struct, Item>> {
@@ -97,6 +104,7 @@ mod __dynosaur_macro_dynnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl Next` to `&DynNext`."]
         pub const fn from_ref(value:
                 &(impl Next<Item = Item> + 'dynosaur_struct))
             -> &DynNext<'dynosaur_struct, Item> {
@@ -104,6 +112,7 @@ mod __dynosaur_macro_dynnext {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl Next` to `&mut DynNext`."]
         pub const fn from_mut(value:
                 &mut (impl Next<Item = Item> + 'dynosaur_struct))
             -> &mut DynNext<'dynosaur_struct, Item> {
@@ -162,6 +171,7 @@ mod __dynosaur_macro_dynsendnext {
             _Box::pin(<Self as SendNext>::next(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`SendNext`]."]
     #[repr(transparent)]
     pub struct DynSendNext<'dynosaur_struct, Item> {
         ptr: dyn ErasedSendNext<Item = Item> + 'dynosaur_struct,
@@ -184,6 +194,8 @@ mod __dynosaur_macro_dynsendnext {
         }
     }
     impl<'dynosaur_struct, Item> DynSendNext<'dynosaur_struct, Item> {
+        #[doc =
+        "Create `Box<DynSendNext>` from a value implementing [`SendNext`]."]
         pub fn new_box(value: impl SendNext<Item = Item> + 'dynosaur_struct)
             -> _Box<DynSendNext<'dynosaur_struct, Item>> {
             let value = _Box::new(value);
@@ -192,6 +204,8 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynSendNext>` from a value implementing [`SendNext`]."]
         pub fn new_arc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
             -> _Arc<DynSendNext<'dynosaur_struct, Item>> {
             let value = _Arc::new(value);
@@ -200,6 +214,8 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynSendNext>` from a value implementing [`SendNext`]."]
         pub fn new_rc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
             -> _Rc<DynSendNext<'dynosaur_struct, Item>> {
             let value = _Rc::new(value);
@@ -208,6 +224,7 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl SendNext>` to `Box<DynSendNext>`."]
         pub const fn from_box(value:
                 _Box<impl SendNext<Item = Item> + 'dynosaur_struct>)
             -> _Box<DynSendNext<'dynosaur_struct, Item>> {
@@ -216,6 +233,7 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl SendNext>` to `Arc<DynSendNext>`."]
         pub const fn from_arc(value:
                 _Arc<impl SendNext<Item = Item> + 'dynosaur_struct>)
             -> _Arc<DynSendNext<'dynosaur_struct, Item>> {
@@ -224,6 +242,7 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl SendNext>` to `Rc<DynSendNext>`."]
         pub const fn from_rc(value:
                 _Rc<impl SendNext<Item = Item> + 'dynosaur_struct>)
             -> _Rc<DynSendNext<'dynosaur_struct, Item>> {
@@ -232,6 +251,7 @@ mod __dynosaur_macro_dynsendnext {
                 value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl SendNext` to `&DynSendNext`."]
         pub const fn from_ref(value:
                 &(impl SendNext<Item = Item> + 'dynosaur_struct))
             -> &DynSendNext<'dynosaur_struct, Item> {
@@ -239,6 +259,7 @@ mod __dynosaur_macro_dynsendnext {
                 &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl SendNext` to `&mut DynSendNext`."]
         pub const fn from_mut(value:
                 &mut (impl SendNext<Item = Item> + 'dynosaur_struct))
             -> &mut DynSendNext<'dynosaur_struct, Item> {

--- a/dynosaur/tests/pass/visibility.stdout
+++ b/dynosaur/tests/pass/visibility.stdout
@@ -30,6 +30,7 @@ mod __dynosaur_macro_dynmytrait {
             _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
+    #[doc = "Dyn-compatible wrapper for [`MyTrait`]."]
     #[repr(transparent)]
     pub struct DynMyTrait<'dynosaur_struct> {
         ptr: dyn ErasedMyTrait + 'dynosaur_struct,
@@ -46,44 +47,55 @@ mod __dynosaur_macro_dynmytrait {
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
+        #[doc =
+        "Create `Box<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value = _Box::new(value);
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Arc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value = _Arc::new(value);
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc =
+        "Create `Rc<DynMyTrait>` from a value implementing [`MyTrait`]."]
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value = _Rc::new(value);
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Box<impl MyTrait>` to `Box<DynMyTrait>`."]
         pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
             -> _Box<DynMyTrait<'dynosaur_struct>> {
             let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Arc<impl MyTrait>` to `Arc<DynMyTrait>`."]
         pub const fn from_arc(value: _Arc<impl MyTrait + 'dynosaur_struct>)
             -> _Arc<DynMyTrait<'dynosaur_struct>> {
             let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `Rc<impl MyTrait>` to `Rc<DynMyTrait>`."]
         pub const fn from_rc(value: _Rc<impl MyTrait + 'dynosaur_struct>)
             -> _Rc<DynMyTrait<'dynosaur_struct>> {
             let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&impl MyTrait` to `&DynMyTrait`."]
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
             -> &DynMyTrait<'dynosaur_struct> {
             let value: &(dyn ErasedMyTrait + 'dynosaur_struct) = &*value;
             unsafe { ::core::mem::transmute(value) }
         }
+        #[doc = "Convert `&mut impl MyTrait` to `&mut DynMyTrait`."]
         pub const fn from_mut(value: &mut (impl MyTrait + 'dynosaur_struct))
             -> &mut DynMyTrait<'dynosaur_struct> {
             let value: &mut (dyn ErasedMyTrait + 'dynosaur_struct) =

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -405,6 +405,7 @@ fn mk_erased_trait_blanket_impl(item_trait: &ItemTrait) -> TokenStream {
 }
 
 fn mk_dyn_struct(struct_ident: &Ident, item_trait: &ItemTrait) -> TokenStream {
+    let trait_ident = &item_trait.ident;
     let erased_trait = mk_erased_trait(&item_trait);
     let erased_trait_ident = &erased_trait.ident;
     let StructTraitParams {
@@ -413,7 +414,10 @@ fn mk_dyn_struct(struct_ident: &Ident, item_trait: &ItemTrait) -> TokenStream {
         ..
     } = struct_trait_params(&erased_trait);
 
+    let doc = format!("Dyn-compatible wrapper for [`{trait_ident}`].");
+
     quote! {
+        #[doc = #doc]
         #[repr(transparent)]
         pub struct #struct_ident #struct_with_bounds_params {
             ptr: dyn #erased_trait_ident #trait_params + 'dynosaur_struct
@@ -485,47 +489,67 @@ fn mk_struct_inherent_impl(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
         _ => {}
     });
 
+    let doc_new_box =
+        format!("Create `Box<{struct_ident}>` from a value implementing [`{trait_ident}`].");
+    let doc_new_arc =
+        format!("Create `Arc<{struct_ident}>` from a value implementing [`{trait_ident}`].");
+    let doc_new_rc =
+        format!("Create `Rc<{struct_ident}>` from a value implementing [`{trait_ident}`].");
+    let doc_from_box = format!("Convert `Box<impl {trait_ident}>` to `Box<{struct_ident}>`.");
+    let doc_from_arc = format!("Convert `Arc<impl {trait_ident}>` to `Arc<{struct_ident}>`.");
+    let doc_from_rc = format!("Convert `Rc<impl {trait_ident}>` to `Rc<{struct_ident}>`.");
+    let doc_from_ref = format!("Convert `&impl {trait_ident}` to `&{struct_ident}`.");
+    let doc_from_mut = format!("Convert `&mut impl {trait_ident}` to `&mut {struct_ident}`.");
+
     quote! {
         impl #struct_with_bounds_params #struct_ident #struct_params
         {
+            #[doc = #doc_new_box]
             pub fn new_box(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Box<#struct_ident #struct_params> {
                 let value = _Box::new(value);
                 let value: _Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_new_arc]
             pub fn new_arc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Arc<#struct_ident #struct_params> {
                 let value = _Arc::new(value);
                 let value: _Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_new_rc]
             pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Rc<#struct_ident #struct_params> {
                 let value = _Rc::new(value);
                 let value: _Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_from_box]
             pub const fn from_box(value: _Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> _Box<#struct_ident #struct_params> {
                 let value: _Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_from_arc]
             pub const fn from_arc(value: _Arc<impl #trait_ident #trait_params + 'dynosaur_struct>) -> _Arc<#struct_ident #struct_params> {
                 let value: _Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_from_rc]
             pub const fn from_rc(value: _Rc<impl #trait_ident #trait_params + 'dynosaur_struct>) -> _Rc<#struct_ident #struct_params> {
                 let value: _Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_from_ref]
             pub const fn from_ref(value: &(impl #trait_ident #trait_params + 'dynosaur_struct)) -> & #struct_ident #struct_params {
                 let value: &(dyn #erased_trait_ident #trait_params + 'dynosaur_struct) = &*value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
+            #[doc = #doc_from_mut]
             pub const fn from_mut(value: &mut (impl #trait_ident #trait_params + 'dynosaur_struct)) -> &mut #struct_ident #struct_params {
                 let value: &mut (dyn #erased_trait_ident #trait_params + 'dynosaur_struct) = &mut *value;
                 unsafe { ::core::mem::transmute(value) }


### PR DESCRIPTION
## Motivation

In a recent project at work, we wanted to switch from `async_trait` to `dynosaur`. However, we `#![deny(missing_docs)]` in all of our crates. This meant that we could not use `dynosaur` because auto-generated DynTraits currently have no documentation.

## Implementation

This PR adds documentation to the auto-generated DynTraits. This documentation just links back to the original Trait documentation.

## Testing

This PR is tested by the new `dynosaur/examples/pub_trait.rs` file. This file roughly matches the use case in my project, where I have a public trait and I make its dyn-wrapper also public. The implementation of MyTrait was adapted from `dynosaur/tests/pass/basic.rs`.

I also did a manual test where I locally rebased my work on PR #109 by tyilo to make sure that it looked alright using `cargo doc --open`. (Aside: I would love to see that PR merged as well!)