### PR TITLE
Allow no_std + alloc builds by avoiding std paths in macro output

### DIFF
--- a/dynosaur/tests/fail/const-attr.stdout
+++ b/dynosaur/tests/fail/const-attr.stdout
@@ -10,20 +10,23 @@ trait Foo {
 }
 mod __dynosaur_macro_dynfoo {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedFoo {
         const BAR: i32;
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: Foo> ErasedFoo for DYNOSAUR {
-        fn foo<'life0, 'dynosaur>(&'life0 self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as Foo>::foo(self))
+        fn foo<'life0, 'dynosaur>(&'life0 self) -> _Box<dyn Send + 'dynosaur>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -32,44 +35,34 @@ mod __dynosaur_macro_dynfoo {
     }
     impl<'dynosaur_struct> Foo for DynFoo<'dynosaur_struct> {
         fn foo(&self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.foo();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.foo();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+            -> _Box<DynFoo<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynFoo<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> =
-                value;
+            -> _Rc<DynFoo<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl Foo + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl Foo + 'dynosaur_struct>)
+            -> _Box<DynFoo<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
@@ -89,8 +82,7 @@ mod __dynosaur_macro_dynfoo {
     impl<DYNOSAUR: Foo> Foo for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as Foo>::foo(self) }
     }
-    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: Foo> Foo for _Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as Foo>::foo(self) }
     }
 }

--- a/dynosaur/tests/fail/const-attr.stdout
+++ b/dynosaur/tests/fail/const-attr.stdout
@@ -9,19 +9,21 @@ trait Foo {
     -> impl Send;
 }
 mod __dynosaur_macro_dynfoo {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedFoo {
         const BAR: i32;
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: Foo> ErasedFoo for DYNOSAUR {
-        fn foo<'life0, 'dynosaur>(&'life0 self) -> Box<dyn Send + 'dynosaur>
-            where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as Foo>::foo(self))
+        fn foo<'life0, 'dynosaur>(&'life0 self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -30,35 +32,44 @@ mod __dynosaur_macro_dynfoo {
     }
     impl<'dynosaur_struct> Foo for DynFoo<'dynosaur_struct> {
         fn foo(&self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.foo();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.foo();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
-            -> Box<DynFoo<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
-            -> std::sync::Arc<DynFoo<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedFoo + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
-            -> std::rc::Rc<DynFoo<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl Foo + 'dynosaur_struct>)
-            -> Box<DynFoo<'dynosaur_struct>> {
-            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl Foo + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
@@ -78,7 +89,8 @@ mod __dynosaur_macro_dynfoo {
     impl<DYNOSAUR: Foo> Foo for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as Foo>::foo(self) }
     }
-    impl<DYNOSAUR: Foo> Foo for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as Foo>::foo(self) }
     }
 }

--- a/dynosaur/tests/fail/self_and_box_receivers.stdout
+++ b/dynosaur/tests/fail/self_and_box_receivers.stdout
@@ -16,44 +16,49 @@ trait All {
     -> impl Send;
 }
 mod __dynosaur_macro_dynall {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedAll {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
         fn owned<'dynosaur>(self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
         fn self_box<'dynosaur>(self: Box<Self>)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
         fn self_rc<'dynosaur>(self: Rc<Self>)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: All> ErasedAll for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as All>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self) -> Box<dyn Send + 'dynosaur>
-            where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as All>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as All>::ref_(self))
         }
-        fn owned<'dynosaur>(self) -> Box<dyn Send + 'dynosaur> where
+        fn owned<'dynosaur>(self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
             Self: 'dynosaur {
-            Box::new(<Self as All>::owned(self))
+            __dynosaur_alloc::boxed::Box::new(<Self as All>::owned(self))
         }
-        fn self_box<'dynosaur>(self: Box<Self>) -> Box<dyn Send + 'dynosaur>
-            where Self: 'dynosaur {
-            Box::new(<Self as All>::self_box(self))
+        fn self_box<'dynosaur>(self: Box<Self>)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as All>::self_box(self))
         }
-        fn self_rc<'dynosaur>(self: Rc<Self>) -> Box<dyn Send + 'dynosaur>
-            where Self: 'dynosaur {
-            Box::new(<Self as All>::self_rc(self))
+        fn self_rc<'dynosaur>(self: Rc<Self>)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as All>::self_rc(self))
         }
     }
     #[repr(transparent)]
@@ -63,53 +68,65 @@ mod __dynosaur_macro_dynall {
     impl<'dynosaur_struct> All for DynAll<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.ref_();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.ref_();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn owned(self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.owned();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.owned();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn self_box(self: Box<Self>) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.self_box();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.self_box();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn self_rc(self: Rc<Self>) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.self_rc();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.self_rc();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
         pub fn new_box(value: impl All + 'dynosaur_struct)
-            -> Box<DynAll<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl All + 'dynosaur_struct)
-            -> std::sync::Arc<DynAll<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedAll + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl All + 'dynosaur_struct)
-            -> std::rc::Rc<DynAll<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedAll + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::rc::Rc<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedAll + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl All + 'dynosaur_struct>)
-            -> Box<DynAll<'dynosaur_struct>> {
-            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl All + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))

--- a/dynosaur/tests/fail/self_and_box_receivers.stdout
+++ b/dynosaur/tests/fail/self_and_box_receivers.stdout
@@ -17,48 +17,48 @@ trait All {
 }
 mod __dynosaur_macro_dynall {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedAll {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
         fn owned<'dynosaur>(self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
         fn self_box<'dynosaur>(self: Box<Self>)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
         fn self_rc<'dynosaur>(self: Rc<Self>)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: All> ErasedAll for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as All>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as All>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self) -> _Box<dyn Send + 'dynosaur>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as All>::ref_(self))
         }
-        fn owned<'dynosaur>(self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+        fn owned<'dynosaur>(self) -> _Box<dyn Send + 'dynosaur> where
             Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as All>::owned(self))
+            _Box::new(<Self as All>::owned(self))
         }
-        fn self_box<'dynosaur>(self: Box<Self>)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as All>::self_box(self))
+        fn self_box<'dynosaur>(self: Box<Self>) -> _Box<dyn Send + 'dynosaur>
+            where Self: 'dynosaur {
+            _Box::new(<Self as All>::self_box(self))
         }
-        fn self_rc<'dynosaur>(self: Rc<Self>)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as All>::self_rc(self))
+        fn self_rc<'dynosaur>(self: Rc<Self>) -> _Box<dyn Send + 'dynosaur>
+            where Self: 'dynosaur {
+            _Box::new(<Self as All>::self_rc(self))
         }
     }
     #[repr(transparent)]
@@ -68,65 +68,52 @@ mod __dynosaur_macro_dynall {
     impl<'dynosaur_struct> All for DynAll<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.ref_();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.ref_();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn owned(self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.owned();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.owned();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn self_box(self: Box<Self>) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.self_box();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.self_box();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn self_rc(self: Rc<Self>) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.self_rc();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.self_rc();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
         pub fn new_box(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+            -> _Box<DynAll<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynAll<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedAll + 'dynosaur_struct> =
-                value;
+            -> _Rc<DynAll<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl All + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl All + 'dynosaur_struct>)
+            -> _Box<DynAll<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))

--- a/dynosaur/tests/fail/where-self-sized-rpit.stdout
+++ b/dynosaur/tests/fail/where-self-sized-rpit.stdout
@@ -13,12 +13,14 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn bar<'life0, 'dynosaur>(&'life0 mut self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -35,50 +37,40 @@ mod __dynosaur_macro_dynmytrait {
 
                 ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'static>>
+                _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.bar();
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.bar();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -99,22 +91,20 @@ mod __dynosaur_macro_dynmytrait {
             Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'static>>
+                _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::bar(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         #[allow(unreachable_code)]
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> where
             Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'static>>
+                _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::bar(self)

--- a/dynosaur/tests/fail/where-self-sized-rpit.stdout
+++ b/dynosaur/tests/fail/where-self-sized-rpit.stdout
@@ -12,12 +12,13 @@ trait MyTrait {
     async fn bar(&mut self);
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn bar<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -34,43 +35,50 @@ mod __dynosaur_macro_dynmytrait {
 
                 ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'static>>
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.bar();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.bar();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -91,21 +99,22 @@ mod __dynosaur_macro_dynmytrait {
             Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'static>>
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::bar(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         #[allow(unreachable_code)]
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> where
             Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
                 as
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'static>>
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'static>>
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::bar(self)

--- a/dynosaur/tests/fail/where-self-sized.stdout
+++ b/dynosaur/tests/fail/where-self-sized.stdout
@@ -11,12 +11,13 @@ trait MyTrait {
     async fn bar(&mut self);
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn bar<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -32,38 +33,45 @@ mod __dynosaur_macro_dynmytrait {
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.bar();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.bar();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -86,7 +94,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::bar(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         async fn foo(&mut self) where Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
         }

--- a/dynosaur/tests/fail/where-self-sized.stdout
+++ b/dynosaur/tests/fail/where-self-sized.stdout
@@ -12,12 +12,14 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn bar<'life0, 'dynosaur>(&'life0 mut self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -33,45 +35,36 @@ mod __dynosaur_macro_dynmytrait {
         }
         fn bar(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.bar();
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.bar();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -94,8 +87,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::bar(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         async fn foo(&mut self) where Self: Sized {
             ::core::panicking::panic("internal error: entered unreachable code")
         }

--- a/dynosaur/tests/pass/anynomous-args.stdout
+++ b/dynosaur/tests/pass/anynomous-args.stdout
@@ -7,14 +7,16 @@ trait SomeTrait {
 }
 mod __dynosaur_macro_dynsometrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedSomeTrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, __dynosaur_arg1: &'life1 u8,
         __dynosaur_arg2: &'life2 u8)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -25,11 +27,10 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
             'dynosaur>(&'life0 self, __dynosaur_arg1: &'life1 u8,
             __dynosaur_arg2: &'life2 u8)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
-            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, 'life1: 'dynosaur, 'life2: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait>::multiple_elided_lifetimes(self, __dynosaur_arg1,
                     __dynosaur_arg2))
         }
@@ -43,48 +44,37 @@ mod __dynosaur_macro_dynsometrait {
             __dynosaur_arg2: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
                 self.ptr.multiple_elided_lifetimes(__dynosaur_arg1,
                     __dynosaur_arg2);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl SomeTrait +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -118,8 +108,8 @@ mod __dynosaur_macro_dynsometrait {
                 __dynosaur_arg2)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn multiple_elided_lifetimes(&self, __dynosaur_arg1: &u8,
             __dynosaur_arg2: &u8)
             -> impl ::core::future::Future<Output = ()> {

--- a/dynosaur/tests/pass/anynomous-args.stdout
+++ b/dynosaur/tests/pass/anynomous-args.stdout
@@ -6,14 +6,15 @@ trait SomeTrait {
     async fn multiple_elided_lifetimes(&self, _: &u8, _: &u8);
 }
 mod __dynosaur_macro_dynsometrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedSomeTrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, __dynosaur_arg1: &'life1 u8,
         __dynosaur_arg2: &'life2 u8)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -25,10 +26,10 @@ mod __dynosaur_macro_dynsometrait {
             'dynosaur>(&'life0 self, __dynosaur_arg1: &'life1 u8,
             __dynosaur_arg2: &'life2 u8)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, 'life1: 'dynosaur,
-            'life2: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
+            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait>::multiple_elided_lifetimes(self, __dynosaur_arg1,
                     __dynosaur_arg2))
         }
@@ -42,41 +43,48 @@ mod __dynosaur_macro_dynsometrait {
             __dynosaur_arg2: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> =
                 self.ptr.multiple_elided_lifetimes(__dynosaur_arg1,
                     __dynosaur_arg2);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl SomeTrait +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -110,8 +118,8 @@ mod __dynosaur_macro_dynsometrait {
                 __dynosaur_arg2)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn multiple_elided_lifetimes(&self, __dynosaur_arg1: &u8,
             __dynosaur_arg2: &u8)
             -> impl ::core::future::Future<Output = ()> {

--- a/dynosaur/tests/pass/associated-types.stdout
+++ b/dynosaur/tests/pass/associated-types.stdout
@@ -11,13 +11,14 @@ trait Foo {
     -> Self::Bar;
 }
 mod __dynosaur_macro_dynfoo {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedFoo {
         type Bar: Baz;
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Self::Bar> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Self::Bar> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -26,10 +27,10 @@ mod __dynosaur_macro_dynfoo {
         type Bar = <Self as Foo>::Bar;
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Self::Bar> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Self::Bar> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as Foo>::foo(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -40,44 +41,47 @@ mod __dynosaur_macro_dynfoo {
         type Bar = Bar;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Bar> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Self::Bar> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Self::Bar> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Self::Bar> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Self::Bar> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Bar: Baz> DynFoo<'dynosaur_struct, Bar> {
         pub fn new_box(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> Box<DynFoo<'dynosaur_struct, Bar>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct, Bar>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo<Bar = Bar> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> std::sync::Arc<DynFoo<'dynosaur_struct, Bar>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct, Bar>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedFoo<Bar = Bar> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo<Bar = Bar> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> std::rc::Rc<DynFoo<'dynosaur_struct, Bar>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct, Bar>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo<Bar = Bar> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl Foo<Bar = Bar> + 'dynosaur_struct>)
-            -> Box<DynFoo<'dynosaur_struct, Bar>> {
-            let value: Box<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
-                value;
+                __dynosaur_alloc::boxed::Box<impl Foo<Bar = Bar> +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct, Bar>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo<Bar = Bar> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -107,7 +111,8 @@ mod __dynosaur_macro_dynfoo {
             <DYNOSAUR as Foo>::foo(self)
         }
     }
-    impl<DYNOSAUR: Foo> Foo for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         type Bar = <DYNOSAUR as Foo>::Bar;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Bar> {
             <DYNOSAUR as Foo>::foo(self)

--- a/dynosaur/tests/pass/associated-types.stdout
+++ b/dynosaur/tests/pass/associated-types.stdout
@@ -12,13 +12,17 @@ trait Foo {
 }
 mod __dynosaur_macro_dynfoo {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedFoo {
         type Bar: Baz;
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Self::Bar> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output = Self::Bar> +
+            'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -27,10 +31,9 @@ mod __dynosaur_macro_dynfoo {
         type Bar = <Self as Foo>::Bar;
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Self::Bar> + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as Foo>::foo(self))
+                _Pin<_Box<dyn ::core::future::Future<Output = Self::Bar> +
+                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -41,47 +44,41 @@ mod __dynosaur_macro_dynfoo {
         type Bar = Bar;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Bar> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Self::Bar> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = Self::Bar> +
+                    '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Self::Bar> + 'static>> =
-                unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = Self::Bar> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Bar: Baz> DynFoo<'dynosaur_struct, Bar> {
         pub fn new_box(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct, Bar>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo<Bar = Bar> +
-                    'dynosaur_struct> = value;
+            -> _Box<DynFoo<'dynosaur_struct, Bar>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct, Bar>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo<Bar = Bar> +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynFoo<'dynosaur_struct, Bar>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo<Bar = Bar> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct, Bar>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo<Bar = Bar> +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynFoo<'dynosaur_struct, Bar>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl Foo<Bar = Bar> +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct, Bar>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo<Bar = Bar> +
-                    'dynosaur_struct> = value;
+                _Box<impl Foo<Bar = Bar> + 'dynosaur_struct>)
+            -> _Box<DynFoo<'dynosaur_struct, Bar>> {
+            let value: _Box<dyn ErasedFoo<Bar = Bar> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -111,8 +108,7 @@ mod __dynosaur_macro_dynfoo {
             <DYNOSAUR as Foo>::foo(self)
         }
     }
-    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: Foo> Foo for _Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         type Bar = <DYNOSAUR as Foo>::Bar;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Bar> {
             <DYNOSAUR as Foo>::foo(self)

--- a/dynosaur/tests/pass/async-and-non-async.stdout
+++ b/dynosaur/tests/pass/async-and-non-async.stdout
@@ -10,14 +10,15 @@ pub trait JobQueue {
     async fn dispatch(&self);
 }
 mod __dynosaur_macro_dynjobqueue {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     pub trait ErasedJobQueue {
         fn len(&self)
         -> usize;
         fn dispatch<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -26,9 +27,10 @@ mod __dynosaur_macro_dynjobqueue {
         fn len(&self) -> usize { <Self as JobQueue>::len(self) }
         fn dispatch<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as JobQueue>::dispatch(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
+                        JobQueue>::dispatch(self))
         }
     }
     #[repr(transparent)]
@@ -39,38 +41,46 @@ mod __dynosaur_macro_dynjobqueue {
         fn len(&self) -> usize { self.ptr.len() }
         fn dispatch(&self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.dispatch();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.dispatch();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynJobQueue<'dynosaur_struct> {
         pub fn new_box(value: impl JobQueue + 'dynosaur_struct)
-            -> Box<DynJobQueue<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynJobQueue<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedJobQueue +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl JobQueue + 'dynosaur_struct)
-            -> std::sync::Arc<DynJobQueue<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedJobQueue + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynJobQueue<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedJobQueue +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl JobQueue + 'dynosaur_struct)
-            -> std::rc::Rc<DynJobQueue<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedJobQueue + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynJobQueue<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedJobQueue +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl JobQueue + 'dynosaur_struct>)
-            -> Box<DynJobQueue<'dynosaur_struct>> {
-            let value: Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl JobQueue +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynJobQueue<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedJobQueue +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
@@ -98,8 +108,8 @@ mod __dynosaur_macro_dynjobqueue {
             <DYNOSAUR as JobQueue>::dispatch(self)
         }
     }
-    impl<DYNOSAUR: JobQueue> JobQueue for Box<DYNOSAUR> where DYNOSAUR: ?Sized
-        {
+    impl<DYNOSAUR: JobQueue> JobQueue for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn len(&self) -> usize { <DYNOSAUR as JobQueue>::len(self) }
         fn dispatch(&self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as JobQueue>::dispatch(self)

--- a/dynosaur/tests/pass/async-and-non-async.stdout
+++ b/dynosaur/tests/pass/async-and-non-async.stdout
@@ -11,14 +11,16 @@ pub trait JobQueue {
 }
 mod __dynosaur_macro_dynjobqueue {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     pub trait ErasedJobQueue {
         fn len(&self)
         -> usize;
         fn dispatch<'life0, 'dynosaur>(&'life0 self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -26,11 +28,9 @@ mod __dynosaur_macro_dynjobqueue {
     impl<DYNOSAUR: JobQueue> ErasedJobQueue for DYNOSAUR {
         fn len(&self) -> usize { <Self as JobQueue>::len(self) }
         fn dispatch<'life0, 'dynosaur>(&'life0 self)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
-                        JobQueue>::dispatch(self))
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as JobQueue>::dispatch(self))
         }
     }
     #[repr(transparent)]
@@ -41,46 +41,36 @@ mod __dynosaur_macro_dynjobqueue {
         fn len(&self) -> usize { self.ptr.len() }
         fn dispatch(&self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.dispatch();
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.dispatch();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynJobQueue<'dynosaur_struct> {
         pub fn new_box(value: impl JobQueue + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynJobQueue<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedJobQueue +
-                    'dynosaur_struct> = value;
+            -> _Box<DynJobQueue<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl JobQueue + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynJobQueue<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedJobQueue +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynJobQueue<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl JobQueue + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynJobQueue<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedJobQueue +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynJobQueue<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl JobQueue +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynJobQueue<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedJobQueue +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl JobQueue + 'dynosaur_struct>)
+            -> _Box<DynJobQueue<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedJobQueue + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl JobQueue + 'dynosaur_struct))
@@ -108,8 +98,8 @@ mod __dynosaur_macro_dynjobqueue {
             <DYNOSAUR as JobQueue>::dispatch(self)
         }
     }
-    impl<DYNOSAUR: JobQueue> JobQueue for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: JobQueue> JobQueue for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn len(&self) -> usize { <DYNOSAUR as JobQueue>::len(self) }
         fn dispatch(&self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as JobQueue>::dispatch(self)

--- a/dynosaur/tests/pass/basic-apit.stdout
+++ b/dynosaur/tests/pass/basic-apit.stdout
@@ -18,37 +18,48 @@ trait MyTrait {
     -> i32;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
-        fn foo(&self, __dynosaur_arg1: Box<dyn Foo + '_>)
+        fn foo(&self,
+        __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + '_>)
         -> i32;
         fn bar<'life0,
-        'dynosaur>(&'life0 self, __dynosaur_arg1: Box<dyn Foo + 'dynosaur>)
+        'dynosaur>(&'life0 self,
+        __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + 'dynosaur>)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = i32> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
         fn baz(&self,
-        __dynosaur_arg1: ::core::pin::Pin<Box<dyn Future<Output = i32> + '_>>)
+        __dynosaur_arg1:
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
+            i32> + '_>>)
         -> i32;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
-        fn foo(&self, __dynosaur_arg1: Box<dyn Foo + '_>) -> i32 {
+        fn foo(&self,
+            __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + '_>)
+            -> i32 {
             <Self as MyTrait>::foo(self, __dynosaur_arg1)
         }
         fn bar<'life0,
             'dynosaur>(&'life0 self,
-            __dynosaur_arg1: Box<dyn Foo + 'dynosaur>)
+            __dynosaur_arg1:
+                __dynosaur_alloc::boxed::Box<dyn Foo + 'dynosaur>)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                i32> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::bar(self, __dynosaur_arg1))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
+                        MyTrait>::bar(self, __dynosaur_arg1))
         }
         fn baz(&self,
             __dynosaur_arg1:
-                ::core::pin::Pin<Box<dyn Future<Output = i32> + '_>>) -> i32 {
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                = i32> + '_>>) -> i32 {
             <Self as MyTrait>::baz(self, __dynosaur_arg1)
         }
     }
@@ -58,46 +69,54 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self, __dynosaur_arg1: impl Foo) -> i32 {
-            self.ptr.foo(Box::new(__dynosaur_arg1))
+            self.ptr.foo(__dynosaur_alloc::boxed::Box::new(__dynosaur_arg1))
         }
         fn bar(&self, __dynosaur_arg1: impl Foo)
             -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + '_>> = self.ptr.bar(Box::new(__dynosaur_arg1));
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + '_>> =
+                self.ptr.bar(__dynosaur_alloc::boxed::Box::new(__dynosaur_arg1));
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn baz(&self, __dynosaur_arg1: impl Future<Output = i32>) -> i32 {
-            self.ptr.baz(Box::pin(__dynosaur_arg1))
+            self.ptr.baz(__dynosaur_alloc::boxed::Box::pin(__dynosaur_arg1))
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -136,7 +155,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::baz(self, __dynosaur_arg1)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&self, __dynosaur_arg1: impl Foo) -> i32 {
             <DYNOSAUR as MyTrait>::foo(self, __dynosaur_arg1)
         }

--- a/dynosaur/tests/pass/basic-apit.stdout
+++ b/dynosaur/tests/pass/basic-apit.stdout
@@ -19,47 +19,39 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
-        fn foo(&self,
-        __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + '_>)
+        fn foo(&self, __dynosaur_arg1: _Box<dyn Foo + '_>)
         -> i32;
         fn bar<'life0,
-        'dynosaur>(&'life0 self,
-        __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + 'dynosaur>)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = i32> + 'dynosaur>>
+        'dynosaur>(&'life0 self, __dynosaur_arg1: _Box<dyn Foo + 'dynosaur>)
+        -> _Pin<_Box<dyn ::core::future::Future<Output = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
         fn baz(&self,
-        __dynosaur_arg1:
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
-            i32> + '_>>)
+        __dynosaur_arg1: _Pin<_Box<dyn Future<Output = i32> + '_>>)
         -> i32;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
-        fn foo(&self,
-            __dynosaur_arg1: __dynosaur_alloc::boxed::Box<dyn Foo + '_>)
-            -> i32 {
+        fn foo(&self, __dynosaur_arg1: _Box<dyn Foo + '_>) -> i32 {
             <Self as MyTrait>::foo(self, __dynosaur_arg1)
         }
         fn bar<'life0,
             'dynosaur>(&'life0 self,
-            __dynosaur_arg1:
-                __dynosaur_alloc::boxed::Box<dyn Foo + 'dynosaur>)
+            __dynosaur_arg1: _Box<dyn Foo + 'dynosaur>)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
-                        MyTrait>::bar(self, __dynosaur_arg1))
+                _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::bar(self, __dynosaur_arg1))
         }
         fn baz(&self,
-            __dynosaur_arg1:
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                = i32> + '_>>) -> i32 {
+            __dynosaur_arg1: _Pin<_Box<dyn Future<Output = i32> + '_>>)
+            -> i32 {
             <Self as MyTrait>::baz(self, __dynosaur_arg1)
         }
     }
@@ -69,54 +61,44 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self, __dynosaur_arg1: impl Foo) -> i32 {
-            self.ptr.foo(__dynosaur_alloc::boxed::Box::new(__dynosaur_arg1))
+            self.ptr.foo(_Box::new(__dynosaur_arg1))
         }
         fn bar(&self, __dynosaur_arg1: impl Foo)
             -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + '_>> =
-                self.ptr.bar(__dynosaur_alloc::boxed::Box::new(__dynosaur_arg1));
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> + '_>> =
+                self.ptr.bar(_Box::new(__dynosaur_arg1));
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn baz(&self, __dynosaur_arg1: impl Future<Output = i32>) -> i32 {
-            self.ptr.baz(__dynosaur_alloc::boxed::Box::pin(__dynosaur_arg1))
+            self.ptr.baz(_Box::pin(__dynosaur_arg1))
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -155,8 +137,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::baz(self, __dynosaur_arg1)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&self, __dynosaur_arg1: impl Foo) -> i32 {
             <DYNOSAUR as MyTrait>::foo(self, __dynosaur_arg1)
         }

--- a/dynosaur/tests/pass/basic-mut.stdout
+++ b/dynosaur/tests/pass/basic-mut.stdout
@@ -9,22 +9,23 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -34,45 +35,36 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -92,8 +84,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/basic-mut.stdout
+++ b/dynosaur/tests/pass/basic-mut.stdout
@@ -8,12 +8,13 @@ trait MyTrait {
     async fn foo(&mut self);
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -21,9 +22,9 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -33,38 +34,45 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -84,7 +92,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&mut self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/basic-no-ret.stdout
+++ b/dynosaur/tests/pass/basic-no-ret.stdout
@@ -8,12 +8,13 @@ trait MyTrait {
     async fn foo(&self);
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -21,9 +22,9 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -33,38 +34,45 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -89,7 +97,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/basic-no-ret.stdout
+++ b/dynosaur/tests/pass/basic-no-ret.stdout
@@ -9,22 +9,23 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -34,45 +35,36 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -97,8 +89,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&self) -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/basic-rpitit.stdout
+++ b/dynosaur/tests/pass/basic-rpitit.stdout
@@ -9,18 +9,20 @@ trait MyTrait {
     -> impl Send;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
-        fn foo<'life0, 'dynosaur>(&'life0 self) -> Box<dyn Send + 'dynosaur>
-            where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as MyTrait>::foo(self))
+        fn foo<'life0, 'dynosaur>(&'life0 self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -29,36 +31,44 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.foo();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.foo();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -79,7 +89,8 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> MyTrait for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
 }

--- a/dynosaur/tests/pass/basic-rpitit.stdout
+++ b/dynosaur/tests/pass/basic-rpitit.stdout
@@ -10,19 +10,22 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
-        fn foo<'life0, 'dynosaur>(&'life0 self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as MyTrait>::foo(self))
+        fn foo<'life0, 'dynosaur>(&'life0 self) -> _Box<dyn Send + 'dynosaur>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -31,44 +34,34 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.foo();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.foo();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -89,8 +82,8 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> MyTrait for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
 }

--- a/dynosaur/tests/pass/basic-with-self.stdout
+++ b/dynosaur/tests/pass/basic-with-self.stdout
@@ -10,13 +10,14 @@ trait MyTrait {
     -> Self::Item;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         type Item;
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Self::Item> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Self::Item> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -25,10 +26,10 @@ mod __dynosaur_macro_dynmytrait {
         type Item = <Self as MyTrait>::Item;
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Self::Item> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Self::Item> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -40,46 +41,53 @@ mod __dynosaur_macro_dynmytrait {
         type Item = Item;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Item> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Self::Item> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Self::Item> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Self::Item> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Self::Item> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedMyTrait<Item = Item> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedMyTrait<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl MyTrait<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -110,7 +118,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         type Item = <DYNOSAUR as MyTrait>::Item;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Item> {
             <DYNOSAUR as MyTrait>::foo(self)

--- a/dynosaur/tests/pass/basic-with-self.stdout
+++ b/dynosaur/tests/pass/basic-with-self.stdout
@@ -11,13 +11,17 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         type Item;
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Self::Item> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output = Self::Item> +
+            'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -26,10 +30,9 @@ mod __dynosaur_macro_dynmytrait {
         type Item = <Self as MyTrait>::Item;
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Self::Item> + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
+                _Pin<_Box<dyn ::core::future::Future<Output = Self::Item> +
+                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -41,53 +44,45 @@ mod __dynosaur_macro_dynmytrait {
         type Item = Item;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Item> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Self::Item> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = Self::Item> +
+                    '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Self::Item> + 'static>> =
-                unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = Self::Item> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Arc<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Rc<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
-                Item>> {
+                _Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -118,8 +113,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         type Item = <DYNOSAUR as MyTrait>::Item;
         fn foo(&self) -> impl ::core::future::Future<Output = Self::Item> {
             <DYNOSAUR as MyTrait>::foo(self)

--- a/dynosaur/tests/pass/basic.stdout
+++ b/dynosaur/tests/pass/basic.stdout
@@ -10,12 +10,14 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = i32> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -23,10 +25,9 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
+                _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -36,45 +37,36 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> + '_>> =
+                self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -99,8 +91,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/basic.stdout
+++ b/dynosaur/tests/pass/basic.stdout
@@ -9,12 +9,13 @@ trait MyTrait {
     -> i32;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = i32> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -22,9 +23,10 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                i32> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -34,38 +36,45 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -90,7 +99,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/bridge-attr.stdout
+++ b/dynosaur/tests/pass/bridge-attr.stdout
@@ -9,13 +9,17 @@ trait NextNone {
 }
 mod __dynosaur_macro_dynnextnone {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedNextNone {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Option<Self::Item>> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output =
+            Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -24,10 +28,10 @@ mod __dynosaur_macro_dynnextnone {
         type Item = <Self as NextNone>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                _Pin<_Box<dyn ::core::future::Future<Output =
+                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as NextNone>::next(self))
+            _Box::pin(<Self as NextNone>::next(self))
         }
     }
     #[repr(transparent)]
@@ -40,53 +44,46 @@ mod __dynosaur_macro_dynnextnone {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + '_>> = self.ptr.next();
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + 'static>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNextNone<'dynosaur_struct, Item> {
         pub fn new_box(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextNone<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynNextNone<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextNone<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynNextNone<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynNextNone<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedNextNone<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Arc<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynNextNone<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynNextNone<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedNextNone<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Rc<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl NextNone<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextNone<'dynosaur_struct,
-                Item>> {
+                _Box<impl NextNone<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynNextNone<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextNone<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -115,13 +112,17 @@ trait NextDefault {
 }
 mod __dynosaur_macro_dynnextdefault {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedNextDefault {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Option<Self::Item>> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output =
+            Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -130,11 +131,10 @@ mod __dynosaur_macro_dynnextdefault {
         type Item = <Self as NextDefault>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                _Pin<_Box<dyn ::core::future::Future<Output =
+                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
-                        NextDefault>::next(self))
+            _Box::pin(<Self as NextDefault>::next(self))
         }
     }
     #[repr(transparent)]
@@ -147,11 +147,11 @@ mod __dynosaur_macro_dynnextdefault {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + '_>> = self.ptr.next();
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + 'static>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
@@ -159,45 +159,36 @@ mod __dynosaur_macro_dynnextdefault {
     impl<'dynosaur_struct, Item> DynNextDefault<'dynosaur_struct, Item> {
         pub fn new_box(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextDefault<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynNextDefault<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDefault<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextDefault<Item = Item> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynNextDefault<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynNextDefault<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedNextDefault<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Arc<dyn ErasedNextDefault<Item = Item> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextDefault<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::rc::Rc<DynNextDefault<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynNextDefault<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedNextDefault<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Rc<dyn ErasedNextDefault<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl NextDefault<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextDefault<'dynosaur_struct,
-                Item>> {
+                _Box<impl NextDefault<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynNextDefault<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDefault<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextDefault<Item = Item> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -225,8 +216,8 @@ mod __dynosaur_macro_dynnextdefault {
             <DYNOSAUR as NextDefault>::next(self)
         }
     }
-    impl<DYNOSAUR: NextDefault> NextDefault for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: NextDefault> NextDefault for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         type Item = <DYNOSAUR as NextDefault>::Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
@@ -243,13 +234,17 @@ trait NextDyn {
 }
 mod __dynosaur_macro_dynnextdyn {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedNextDyn {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Option<Self::Item>> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output =
+            Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -258,10 +253,10 @@ mod __dynosaur_macro_dynnextdyn {
         type Item = <Self as NextDyn>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                _Pin<_Box<dyn ::core::future::Future<Output =
+                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as NextDyn>::next(self))
+            _Box::pin(<Self as NextDyn>::next(self))
         }
     }
     #[repr(transparent)]
@@ -274,53 +269,46 @@ mod __dynosaur_macro_dynnextdyn {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + '_>> = self.ptr.next();
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + 'static>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNextDyn<'dynosaur_struct, Item> {
         pub fn new_box(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynNextDyn<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDyn<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynNextDyn<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynNextDyn<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedNextDyn<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Arc<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynNextDyn<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynNextDyn<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedNextDyn<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Rc<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl NextDyn<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct,
-                Item>> {
+                _Box<impl NextDyn<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynNextDyn<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDyn<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -348,7 +336,7 @@ mod __dynosaur_macro_dynnextdyn {
         }
     }
     impl<'dynosaur_struct, Item> NextDyn for
-        __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct, Item>> {
+        _Box<DynNextDyn<'dynosaur_struct, Item>> {
         type Item = Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {

--- a/dynosaur/tests/pass/bridge-attr.stdout
+++ b/dynosaur/tests/pass/bridge-attr.stdout
@@ -8,13 +8,14 @@ trait NextNone {
     -> Option<Self::Item>;
 }
 mod __dynosaur_macro_dynnextnone {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedNextNone {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Option<Self::Item>> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -23,10 +24,10 @@ mod __dynosaur_macro_dynnextnone {
         type Item = <Self as NextNone>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as NextNone>::next(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as NextNone>::next(self))
         }
     }
     #[repr(transparent)]
@@ -39,46 +40,53 @@ mod __dynosaur_macro_dynnextnone {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + '_>> = self.ptr.next();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNextNone<'dynosaur_struct, Item> {
         pub fn new_box(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            -> Box<DynNextNone<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextNone<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextNone<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynNextNone<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynNextNone<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedNextNone<Item = Item> +
-                    'dynosaur_struct> = value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedNextNone<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextNone<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynNextNone<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynNextNone<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedNextNone<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedNextNone<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl NextNone<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynNextNone<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl NextNone<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextNone<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedNextNone<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextNone<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -106,13 +114,14 @@ trait NextDefault {
     -> Option<Self::Item>;
 }
 mod __dynosaur_macro_dynnextdefault {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedNextDefault {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Option<Self::Item>> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -121,10 +130,11 @@ mod __dynosaur_macro_dynnextdefault {
         type Item = <Self as NextDefault>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as NextDefault>::next(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as
+                        NextDefault>::next(self))
         }
     }
     #[repr(transparent)]
@@ -137,11 +147,11 @@ mod __dynosaur_macro_dynnextdefault {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + '_>> = self.ptr.next();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
@@ -149,36 +159,45 @@ mod __dynosaur_macro_dynnextdefault {
     impl<'dynosaur_struct, Item> DynNextDefault<'dynosaur_struct, Item> {
         pub fn new_box(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
-            -> Box<DynNextDefault<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextDefault<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedNextDefault<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDefault<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value:
                 impl NextDefault<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynNextDefault<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynNextDefault<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedNextDefault<Item = Item> +
-                    'dynosaur_struct> = value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedNextDefault<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextDefault<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynNextDefault<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            ->
+                __dynosaur_alloc::rc::Rc<DynNextDefault<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedNextDefault<Item = Item> +
-                    'dynosaur_struct> = value;
+                    __dynosaur_alloc::rc::Rc<dyn ErasedNextDefault<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl NextDefault<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynNextDefault<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl NextDefault<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextDefault<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedNextDefault<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDefault<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -206,8 +225,8 @@ mod __dynosaur_macro_dynnextdefault {
             <DYNOSAUR as NextDefault>::next(self)
         }
     }
-    impl<DYNOSAUR: NextDefault> NextDefault for Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: NextDefault> NextDefault for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         type Item = <DYNOSAUR as NextDefault>::Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
@@ -223,13 +242,14 @@ trait NextDyn {
     -> Option<Self::Item>;
 }
 mod __dynosaur_macro_dynnextdyn {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedNextDyn {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Option<Self::Item>> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -238,10 +258,10 @@ mod __dynosaur_macro_dynnextdyn {
         type Item = <Self as NextDyn>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as NextDyn>::next(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as NextDyn>::next(self))
         }
     }
     #[repr(transparent)]
@@ -254,46 +274,53 @@ mod __dynosaur_macro_dynnextdyn {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + '_>> = self.ptr.next();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNextDyn<'dynosaur_struct, Item> {
         pub fn new_box(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            -> Box<DynNextDyn<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDyn<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynNextDyn<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynNextDyn<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedNextDyn<Item = Item> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedNextDyn<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl NextDyn<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynNextDyn<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynNextDyn<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedNextDyn<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedNextDyn<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl NextDyn<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynNextDyn<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl NextDyn<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedNextDyn<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNextDyn<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -321,7 +348,7 @@ mod __dynosaur_macro_dynnextdyn {
         }
     }
     impl<'dynosaur_struct, Item> NextDyn for
-        Box<DynNextDyn<'dynosaur_struct, Item>> {
+        __dynosaur_alloc::boxed::Box<DynNextDyn<'dynosaur_struct, Item>> {
         type Item = Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {

--- a/dynosaur/tests/pass/default-method-trait.stdout
+++ b/dynosaur/tests/pass/default-method-trait.stdout
@@ -8,19 +8,20 @@ trait MyTrait {
     fn foo(&mut self) -> impl Send { 10 }
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-            -> Box<dyn Send + 'dynosaur> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            Box::new(<Self as MyTrait>::foo(self))
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -29,36 +30,44 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&mut self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.foo();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.foo();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -76,7 +85,8 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> MyTrait for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&mut self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&mut self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
 }

--- a/dynosaur/tests/pass/default-method-trait.stdout
+++ b/dynosaur/tests/pass/default-method-trait.stdout
@@ -9,19 +9,23 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 mut self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as MyTrait>::foo(self))
+            -> _Box<dyn Send + 'dynosaur> where 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::new(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -30,44 +34,34 @@ mod __dynosaur_macro_dynmytrait {
     }
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&mut self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.foo();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.foo();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -85,8 +79,8 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> MyTrait for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn foo(&mut self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&mut self) -> impl Send { <DYNOSAUR as MyTrait>::foo(self) }
     }
 }

--- a/dynosaur/tests/pass/generics-in-trait-def.stdout
+++ b/dynosaur/tests/pass/generics-in-trait-def.stdout
@@ -12,13 +12,14 @@ pub trait Service<Request> {
     -> impl Future<Output = Result<Self::Response, Self::Error>>;
 }
 mod __dynosaur_macro_dynservice {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     pub trait ErasedService<Request> {
         type Response;
         type Error;
         fn call<'life0, 'dynosaur>(&'life0 self, req: Request)
         ->
-            ::core::pin::Pin<Box<dyn Future<Output =
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
             Result<Self::Response, Self::Error>> + 'dynosaur>>
         where
         Request: 'dynosaur,
@@ -31,10 +32,11 @@ mod __dynosaur_macro_dynservice {
         type Error = <Self as Service<Request>>::Error;
         fn call<'life0, 'dynosaur>(&'life0 self, req: Request)
             ->
-                ::core::pin::Pin<Box<dyn Future<Output =
-                Result<Self::Response, Self::Error>> + 'dynosaur>> where
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                = Result<Self::Response, Self::Error>> + 'dynosaur>> where
             Request: 'dynosaur, 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as Service<Request>>::call(self, req))
+            __dynosaur_alloc::boxed::Box::pin(<Self as
+                        Service<Request>>::call(self, req))
         }
     }
     #[repr(transparent)]
@@ -49,12 +51,12 @@ mod __dynosaur_macro_dynservice {
         fn call(&self, req: Request)
             -> impl Future<Output = Result<Self::Response, Self::Error>> {
             let ret:
-                    ::core::pin::Pin<Box<dyn Future<Output =
-                    Result<Self::Response, Self::Error>> + '_>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                    = Result<Self::Response, Self::Error>> + '_>> =
                 self.ptr.call(req);
             let ret:
-                    ::core::pin::Pin<Box<dyn Future<Output =
-                    Result<Self::Response, Self::Error>> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                    = Result<Self::Response, Self::Error>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
@@ -64,44 +66,51 @@ mod __dynosaur_macro_dynservice {
         pub fn new_box(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
-            -> Box<DynService<'dynosaur_struct, Request, Response, Error>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynService<'dynosaur_struct,
+                Request, Response, Error>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedService<Request, Response = Response, Error =
-                    Error> + 'dynosaur_struct> = value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedService<Request,
+                    Response = Response, Error = Error> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
             ->
-                std::sync::Arc<DynService<'dynosaur_struct, Request, Response,
-                Error>> {
-            let value = std::sync::Arc::new(value);
+                __dynosaur_alloc::sync::Arc<DynService<'dynosaur_struct,
+                Request, Response, Error>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedService<Request, Response =
-                    Response, Error = Error> + 'dynosaur_struct> = value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedService<Request,
+                    Response = Response, Error = Error> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
             ->
-                std::rc::Rc<DynService<'dynosaur_struct, Request, Response,
-                Error>> {
-            let value = std::rc::Rc::new(value);
+                __dynosaur_alloc::rc::Rc<DynService<'dynosaur_struct, Request,
+                Response, Error>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedService<Request, Response = Response,
-                    Error = Error> + 'dynosaur_struct> = value;
+                    __dynosaur_alloc::rc::Rc<dyn ErasedService<Request, Response
+                    = Response, Error = Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl Service<Request, Response = Response, Error =
-                Error> + 'dynosaur_struct>)
-            -> Box<DynService<'dynosaur_struct, Request, Response, Error>> {
+                __dynosaur_alloc::boxed::Box<impl Service<Request, Response =
+                Response, Error = Error> + 'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynService<'dynosaur_struct,
+                Request, Response, Error>> {
             let value:
-                    Box<dyn ErasedService<Request, Response = Response, Error =
-                    Error> + 'dynosaur_struct> = value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedService<Request,
+                    Response = Response, Error = Error> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -142,7 +151,7 @@ mod __dynosaur_macro_dynservice {
         }
     }
     impl<Request, DYNOSAUR: Service<Request>> Service<Request> for
-        Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         type Response = <DYNOSAUR as Service<Request>>::Response;
         type Error = <DYNOSAUR as Service<Request>>::Error;
         fn call(&self, req: Request)

--- a/dynosaur/tests/pass/generics-in-trait-def.stdout
+++ b/dynosaur/tests/pass/generics-in-trait-def.stdout
@@ -13,13 +13,17 @@ pub trait Service<Request> {
 }
 mod __dynosaur_macro_dynservice {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     pub trait ErasedService<Request> {
         type Response;
         type Error;
         fn call<'life0, 'dynosaur>(&'life0 self, req: Request)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
+            _Pin<_Box<dyn Future<Output =
             Result<Self::Response, Self::Error>> + 'dynosaur>>
         where
         Request: 'dynosaur,
@@ -32,11 +36,10 @@ mod __dynosaur_macro_dynservice {
         type Error = <Self as Service<Request>>::Error;
         fn call<'life0, 'dynosaur>(&'life0 self, req: Request)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                = Result<Self::Response, Self::Error>> + 'dynosaur>> where
+                _Pin<_Box<dyn Future<Output =
+                Result<Self::Response, Self::Error>> + 'dynosaur>> where
             Request: 'dynosaur, 'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
-                        Service<Request>>::call(self, req))
+            _Box::pin(<Self as Service<Request>>::call(self, req))
         }
     }
     #[repr(transparent)]
@@ -51,12 +54,12 @@ mod __dynosaur_macro_dynservice {
         fn call(&self, req: Request)
             -> impl Future<Output = Result<Self::Response, Self::Error>> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                    = Result<Self::Response, Self::Error>> + '_>> =
+                    _Pin<_Box<dyn Future<Output =
+                    Result<Self::Response, Self::Error>> + '_>> =
                 self.ptr.call(req);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                    = Result<Self::Response, Self::Error>> + 'static>> =
+                    _Pin<_Box<dyn Future<Output =
+                    Result<Self::Response, Self::Error>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
@@ -66,51 +69,40 @@ mod __dynosaur_macro_dynservice {
         pub fn new_box(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynService<'dynosaur_struct,
-                Request, Response, Error>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynService<'dynosaur_struct, Request, Response, Error>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedService<Request,
-                    Response = Response, Error = Error> + 'dynosaur_struct> =
-                value;
+                    _Box<dyn ErasedService<Request, Response = Response, Error =
+                    Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynService<'dynosaur_struct,
-                Request, Response, Error>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynService<'dynosaur_struct, Request, Response, Error>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedService<Request,
-                    Response = Response, Error = Error> + 'dynosaur_struct> =
-                value;
+                    _Arc<dyn ErasedService<Request, Response = Response, Error =
+                    Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value:
                 impl Service<Request, Response = Response, Error = Error> +
                 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::rc::Rc<DynService<'dynosaur_struct, Request,
-                Response, Error>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynService<'dynosaur_struct, Request, Response, Error>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedService<Request, Response
-                    = Response, Error = Error> + 'dynosaur_struct> = value;
+                    _Rc<dyn ErasedService<Request, Response = Response, Error =
+                    Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl Service<Request, Response =
-                Response, Error = Error> + 'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynService<'dynosaur_struct,
-                Request, Response, Error>> {
+                _Box<impl Service<Request, Response = Response, Error =
+                Error> + 'dynosaur_struct>)
+            -> _Box<DynService<'dynosaur_struct, Request, Response, Error>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedService<Request,
-                    Response = Response, Error = Error> + 'dynosaur_struct> =
-                value;
+                    _Box<dyn ErasedService<Request, Response = Response, Error =
+                    Error> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -151,7 +143,7 @@ mod __dynosaur_macro_dynservice {
         }
     }
     impl<Request, DYNOSAUR: Service<Request>> Service<Request> for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+        _Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         type Response = <DYNOSAUR as Service<Request>>::Response;
         type Error = <DYNOSAUR as Service<Request>>::Error;
         fn call(&self, req: Request)

--- a/dynosaur/tests/pass/handle-lifetimes.stdout
+++ b/dynosaur/tests/pass/handle-lifetimes.stdout
@@ -10,13 +10,14 @@ trait MyTrait {
     -> i32;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         type Item;
         fn foo<'life0, 'life1, 'dynosaur>(&'life0 self, x: &'life1 i32)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = i32> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -26,10 +27,10 @@ mod __dynosaur_macro_dynmytrait {
         type Item = <Self as MyTrait>::Item;
         fn foo<'life0, 'life1, 'dynosaur>(&'life0 self, x: &'life1 i32)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                i32> + 'dynosaur>> where 'life0: 'dynosaur, 'life1: 'dynosaur,
-            Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self, x))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
+            'life1: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self, x))
         }
     }
     #[repr(transparent)]
@@ -41,45 +42,52 @@ mod __dynosaur_macro_dynmytrait {
         type Item = Item;
         fn foo(&self, x: &i32) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + '_>> = self.ptr.foo(x);
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + '_>> = self.ptr.foo(x);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedMyTrait<Item = Item> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedMyTrait<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl MyTrait<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -110,7 +118,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self, x)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         type Item = <DYNOSAUR as MyTrait>::Item;
         fn foo(&self, x: &i32) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self, x)

--- a/dynosaur/tests/pass/handle-lifetimes.stdout
+++ b/dynosaur/tests/pass/handle-lifetimes.stdout
@@ -11,13 +11,15 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         type Item;
         fn foo<'life0, 'life1, 'dynosaur>(&'life0 self, x: &'life1 i32)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = i32> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -27,10 +29,10 @@ mod __dynosaur_macro_dynmytrait {
         type Item = <Self as MyTrait>::Item;
         fn foo<'life0, 'life1, 'dynosaur>(&'life0 self, x: &'life1 i32)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
-            'life1: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self, x))
+                _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                'dynosaur>> where 'life0: 'dynosaur, 'life1: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self, x))
         }
     }
     #[repr(transparent)]
@@ -42,52 +44,45 @@ mod __dynosaur_macro_dynmytrait {
         type Item = Item;
         fn foo(&self, x: &i32) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + '_>> = self.ptr.foo(x);
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> + '_>> =
+                self.ptr.foo(x);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynMyTrait<'dynosaur_struct, Item> {
         pub fn new_box(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Arc<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynMyTrait<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Rc<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct,
-                Item>> {
+                _Box<impl MyTrait<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedMyTrait<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -118,8 +113,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self, x)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         type Item = <DYNOSAUR as MyTrait>::Item;
         fn foo(&self, x: &i32) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self, x)

--- a/dynosaur/tests/pass/impl-future-bounds.stdout
+++ b/dynosaur/tests/pass/impl-future-bounds.stdout
@@ -10,23 +10,23 @@ trait Foo: Send {
 }
 mod __dynosaur_macro_dynfoo {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedFoo: Send {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
-            i32> + Send + 'dynosaur>>
+        -> _Pin<_Box<dyn Future<Output = i32> + Send + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: Foo> ErasedFoo for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                = i32> + Send + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as Foo>::foo(self))
+            -> _Pin<_Box<dyn Future<Output = i32> + Send + 'dynosaur>> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -35,47 +35,35 @@ mod __dynosaur_macro_dynfoo {
     }
     impl<'dynosaur_struct> Foo for DynFoo<'dynosaur_struct> {
         fn foo(&self) -> impl Future<Output = i32> + Send {
-            let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                    = i32> + Send + '_>> = self.ptr.foo();
-            let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
-                    = i32> + Send + 'static>> =
+            let ret: _Pin<_Box<dyn Future<Output = i32> + Send + '_>> =
+                self.ptr.foo();
+            let ret: _Pin<_Box<dyn Future<Output = i32> + Send + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+            -> _Box<DynFoo<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynFoo<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> =
-                value;
+            -> _Rc<DynFoo<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl Foo + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl Foo + 'dynosaur_struct>)
+            -> _Box<DynFoo<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedFoo + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
@@ -100,8 +88,8 @@ mod __dynosaur_macro_dynfoo {
             <DYNOSAUR as Foo>::foo(self)
         }
     }
-    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized, Self: Send {
+    impl<DYNOSAUR: Foo> Foo for _Box<DYNOSAUR> where DYNOSAUR: ?Sized,
+        Self: Send {
         fn foo(&self) -> impl Future<Output = i32> + Send {
             <DYNOSAUR as Foo>::foo(self)
         }

--- a/dynosaur/tests/pass/impl-future-bounds.stdout
+++ b/dynosaur/tests/pass/impl-future-bounds.stdout
@@ -9,10 +9,13 @@ trait Foo: Send {
     -> impl Future<Output = i32> + Send;
 }
 mod __dynosaur_macro_dynfoo {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedFoo: Send {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        -> ::core::pin::Pin<Box<dyn Future<Output = i32> + Send + 'dynosaur>>
+        ->
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output =
+            i32> + Send + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -20,9 +23,10 @@ mod __dynosaur_macro_dynfoo {
     impl<DYNOSAUR: Foo> ErasedFoo for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn Future<Output = i32> + Send +
-                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as Foo>::foo(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                = i32> + Send + 'dynosaur>> where 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as Foo>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -32,37 +36,46 @@ mod __dynosaur_macro_dynfoo {
     impl<'dynosaur_struct> Foo for DynFoo<'dynosaur_struct> {
         fn foo(&self) -> impl Future<Output = i32> + Send {
             let ret:
-                    ::core::pin::Pin<Box<dyn Future<Output = i32> + Send +
-                    '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                    = i32> + Send + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn Future<Output = i32> + Send +
-                    'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn Future<Output
+                    = i32> + Send + 'static>> =
+                unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynFoo<'dynosaur_struct> {
         pub fn new_box(value: impl Foo + 'dynosaur_struct)
-            -> Box<DynFoo<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Foo + 'dynosaur_struct)
-            -> std::sync::Arc<DynFoo<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedFoo + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Foo + 'dynosaur_struct)
-            -> std::rc::Rc<DynFoo<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::rc::Rc<DynFoo<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedFoo + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl Foo + 'dynosaur_struct>)
-            -> Box<DynFoo<'dynosaur_struct>> {
-            let value: Box<dyn ErasedFoo + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl Foo + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynFoo<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedFoo +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl Foo + 'dynosaur_struct))
@@ -87,8 +100,8 @@ mod __dynosaur_macro_dynfoo {
             <DYNOSAUR as Foo>::foo(self)
         }
     }
-    impl<DYNOSAUR: Foo> Foo for Box<DYNOSAUR> where DYNOSAUR: ?Sized,
-        Self: Send {
+    impl<DYNOSAUR: Foo> Foo for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized, Self: Send {
         fn foo(&self) -> impl Future<Output = i32> + Send {
             <DYNOSAUR as Foo>::foo(self)
         }

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
@@ -10,13 +10,14 @@ trait SomeTrait<'a, 'b> {
     'b: 'a;
 }
 mod __dynosaur_macro_dynsometrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedSomeTrait<'a, 'b> {
         fn lotsa_lifetimes<'d, 'e, 'f, 'life0,
         'dynosaur>(&'life0 self, a: &'d u32, b: &'e u32, c: &'f u32)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            &'a u32> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = &'a u32> + 'dynosaur>>
         where
         'b: 'a,
         'a: 'dynosaur,
@@ -32,11 +33,11 @@ mod __dynosaur_macro_dynsometrait {
         fn lotsa_lifetimes<'d, 'e, 'f, 'life0,
             'dynosaur>(&'life0 self, a: &'d u32, b: &'e u32, c: &'f u32)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                &'a u32> + 'dynosaur>> where 'b: 'a, 'a: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = &'a u32> + 'dynosaur>> where 'b: 'a, 'a: 'dynosaur,
             'b: 'dynosaur, 'd: 'dynosaur, 'e: 'dynosaur, 'f: 'dynosaur,
             'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait<'a, 'b>>::lotsa_lifetimes(self, a, b, c))
         }
     }
@@ -50,44 +51,55 @@ mod __dynosaur_macro_dynsometrait {
             'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32)
             -> impl ::core::future::Future<Output = &'a u32> where 'b: 'a {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    &'a u32> + '_>> = self.ptr.lotsa_lifetimes(a, b, c);
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = &'a u32> + '_>> = self.ptr.lotsa_lifetimes(a, b, c);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    &'a u32> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = &'a u32> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, 'a, 'b> DynSomeTrait<'dynosaur_struct, 'a, 'b> {
         pub fn new_box(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            -> Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
-                value;
+            ->
+                __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct,
+                'a, 'b>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait<'a, 'b> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            -> std::sync::Arc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct, 'a,
+                'b>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedSomeTrait<'a, 'b> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait<'a, 'b> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            -> std::rc::Rc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
-            let value = std::rc::Rc::new(value);
+            ->
+                __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct, 'a,
+                'b>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedSomeTrait<'a, 'b> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait<'a, 'b> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
-            -> Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
-            let value: Box<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
-                value;
+                __dynosaur_alloc::boxed::Box<impl SomeTrait<'a, 'b> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct,
+                'a, 'b>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait<'a, 'b> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -122,7 +134,7 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'a, 'b, DYNOSAUR: SomeTrait<'a, 'b>> SomeTrait<'a, 'b> for
-        Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn lotsa_lifetimes<'d, 'e,
             'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32)
             -> impl ::core::future::Future<Output = &'a u32> where 'b: 'a {

--- a/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes-and-where-clauses.stdout
@@ -11,13 +11,17 @@ trait SomeTrait<'a, 'b> {
 }
 mod __dynosaur_macro_dynsometrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedSomeTrait<'a, 'b> {
         fn lotsa_lifetimes<'d, 'e, 'f, 'life0,
         'dynosaur>(&'life0 self, a: &'d u32, b: &'e u32, c: &'f u32)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = &'a u32> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output = &'a u32> +
+            'dynosaur>>
         where
         'b: 'a,
         'a: 'dynosaur,
@@ -33,11 +37,11 @@ mod __dynosaur_macro_dynsometrait {
         fn lotsa_lifetimes<'d, 'e, 'f, 'life0,
             'dynosaur>(&'life0 self, a: &'d u32, b: &'e u32, c: &'f u32)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = &'a u32> + 'dynosaur>> where 'b: 'a, 'a: 'dynosaur,
-            'b: 'dynosaur, 'd: 'dynosaur, 'e: 'dynosaur, 'f: 'dynosaur,
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+                _Pin<_Box<dyn ::core::future::Future<Output = &'a u32> +
+                'dynosaur>> where 'b: 'a, 'a: 'dynosaur, 'b: 'dynosaur,
+            'd: 'dynosaur, 'e: 'dynosaur, 'f: 'dynosaur, 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait<'a, 'b>>::lotsa_lifetimes(self, a, b, c))
         }
     }
@@ -51,55 +55,41 @@ mod __dynosaur_macro_dynsometrait {
             'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32)
             -> impl ::core::future::Future<Output = &'a u32> where 'b: 'a {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = &'a u32> + '_>> = self.ptr.lotsa_lifetimes(a, b, c);
+                    _Pin<_Box<dyn ::core::future::Future<Output = &'a u32> +
+                    '_>> = self.ptr.lotsa_lifetimes(a, b, c);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = &'a u32> + 'static>> =
-                unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = &'a u32> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, 'a, 'b> DynSomeTrait<'dynosaur_struct, 'a, 'b> {
         pub fn new_box(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct,
-                'a, 'b>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait<'a, 'b> +
-                    'dynosaur_struct> = value;
+            -> _Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct, 'a,
-                'b>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait<'a, 'b> +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait<'a, 'b> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct, 'a,
-                'b>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait<'a, 'b> +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl SomeTrait<'a, 'b> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct,
-                'a, 'b>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait<'a, 'b> +
-                    'dynosaur_struct> = value;
+                _Box<impl SomeTrait<'a, 'b> + 'dynosaur_struct>)
+            -> _Box<DynSomeTrait<'dynosaur_struct, 'a, 'b>> {
+            let value: _Box<dyn ErasedSomeTrait<'a, 'b> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -134,7 +124,7 @@ mod __dynosaur_macro_dynsometrait {
         }
     }
     impl<'a, 'b, DYNOSAUR: SomeTrait<'a, 'b>> SomeTrait<'a, 'b> for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+        _Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn lotsa_lifetimes<'d, 'e,
             'f>(&self, a: &'d u32, b: &'e u32, c: &'f u32)
             -> impl ::core::future::Future<Output = &'a u32> where 'b: 'a {

--- a/dynosaur/tests/pass/multiple-lifetimes.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes.stdout
@@ -14,13 +14,15 @@ trait SomeTrait {
 }
 mod __dynosaur_macro_dynsometrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedSomeTrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, a: &'life1 u8, b: &'life2 u8)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -28,9 +30,7 @@ mod __dynosaur_macro_dynsometrait {
         Self: 'dynosaur;
         fn multiple_named_lifetimes<'a, 'b, 'life0, 'life1,
         'dynosaur>(&'life0 self, a: &'a u8, b: &'b u8, c: &'life1 u8)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'a: 'dynosaur,
         'b: 'a + 'dynosaur,
@@ -39,9 +39,7 @@ mod __dynosaur_macro_dynsometrait {
         Self: 'dynosaur;
         fn same_lifetimes_multiple_params<'a, 'life0, 'life1,
         'dynosaur>(&'life0 self, a1: &'a u8, a2: &'a u8, c: &'life1 u8)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = &'a u8> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = &'a u8> + 'dynosaur>>
         where
         'a: 'dynosaur,
         'life0: 'dynosaur,
@@ -49,9 +47,7 @@ mod __dynosaur_macro_dynsometrait {
         Self: 'dynosaur;
         fn multiple_static_and_anonymous<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, a: &'static u8, b: &'life1 u8, c: &'life2 u8)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = ()> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -61,39 +57,36 @@ mod __dynosaur_macro_dynsometrait {
     impl<DYNOSAUR: SomeTrait> ErasedSomeTrait for DYNOSAUR {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
             'dynosaur>(&'life0 self, a: &'life1 u8, b: &'life2 u8)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
-            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, 'life1: 'dynosaur, 'life2: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait>::multiple_elided_lifetimes(self, a, b))
         }
         fn multiple_named_lifetimes<'a, 'b, 'life0, 'life1,
             'dynosaur>(&'life0 self, a: &'a u8, b: &'b u8, c: &'life1 u8)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'a: 'dynosaur, 'b: 'a + 'dynosaur,
-            'life0: 'dynosaur, 'life1: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'a: 'dynosaur, 'b: 'a + 'dynosaur, 'life0: 'dynosaur,
+            'life1: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait>::multiple_named_lifetimes(self, a, b, c))
         }
         fn same_lifetimes_multiple_params<'a, 'life0, 'life1,
             'dynosaur>(&'life0 self, a1: &'a u8, a2: &'a u8, c: &'life1 u8)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = &'a u8> + 'dynosaur>> where 'a: 'dynosaur,
-            'life0: 'dynosaur, 'life1: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+                _Pin<_Box<dyn ::core::future::Future<Output = &'a u8> +
+                'dynosaur>> where 'a: 'dynosaur, 'life0: 'dynosaur,
+            'life1: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait>::same_lifetimes_multiple_params(self, a1, a2, c))
         }
         fn multiple_static_and_anonymous<'life0, 'life1, 'life2,
             'dynosaur>(&'life0 self, a: &'static u8, b: &'life1 u8,
             c: &'life2 u8)
-            ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
-            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as
+            -> _Pin<_Box<dyn ::core::future::Future<Output = ()> + 'dynosaur>>
+            where 'life0: 'dynosaur, 'life1: 'dynosaur, 'life2: 'dynosaur,
+            Self: 'dynosaur {
+            _Box::pin(<Self as
                         SomeTrait>::multiple_static_and_anonymous(self, a, b, c))
         }
     }
@@ -105,80 +98,67 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_elided_lifetimes(&self, a: &u8, b: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.multiple_elided_lifetimes(a, b);
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.multiple_elided_lifetimes(a, b);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn multiple_named_lifetimes<'a,
             'b: 'a>(&self, a: &'a u8, b: &'b u8, c: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> = self.ptr.multiple_named_lifetimes(a, b, c);
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
+                self.ptr.multiple_named_lifetimes(a, b, c);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn same_lifetimes_multiple_params<'a>(&self, a1: &'a u8, a2: &'a u8,
             c: &u8) -> impl ::core::future::Future<Output = &'a u8> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = &'a u8> + '_>> =
-                self.ptr.same_lifetimes_multiple_params(a1, a2, c);
+                    _Pin<_Box<dyn ::core::future::Future<Output = &'a u8> +
+                    '_>> = self.ptr.same_lifetimes_multiple_params(a1, a2, c);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = &'a u8> + 'static>> =
-                unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = &'a u8> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn multiple_static_and_anonymous(&self, a: &'static u8, b: &'_ u8,
             c: &'_ u8) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + '_>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> + '_>> =
                 self.ptr.multiple_static_and_anonymous(a, b, c);
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = ()> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl SomeTrait +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -236,8 +216,8 @@ mod __dynosaur_macro_dynsometrait {
                     SomeTrait>::multiple_static_and_anonymous(self, a, b, c)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn multiple_elided_lifetimes(&self, a: &u8, b: &u8)
             -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as SomeTrait>::multiple_elided_lifetimes(self, a, b)

--- a/dynosaur/tests/pass/multiple-lifetimes.stdout
+++ b/dynosaur/tests/pass/multiple-lifetimes.stdout
@@ -13,13 +13,14 @@ trait SomeTrait {
     c: &'_ u8);
 }
 mod __dynosaur_macro_dynsometrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedSomeTrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, a: &'life1 u8, b: &'life2 u8)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -28,8 +29,8 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_named_lifetimes<'a, 'b, 'life0, 'life1,
         'dynosaur>(&'life0 self, a: &'a u8, b: &'b u8, c: &'life1 u8)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'a: 'dynosaur,
         'b: 'a + 'dynosaur,
@@ -39,8 +40,8 @@ mod __dynosaur_macro_dynsometrait {
         fn same_lifetimes_multiple_params<'a, 'life0, 'life1,
         'dynosaur>(&'life0 self, a1: &'a u8, a2: &'a u8, c: &'life1 u8)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = &'a u8> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = &'a u8> + 'dynosaur>>
         where
         'a: 'dynosaur,
         'life0: 'dynosaur,
@@ -49,8 +50,8 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_static_and_anonymous<'life0, 'life1, 'life2,
         'dynosaur>(&'life0 self, a: &'static u8, b: &'life1 u8, c: &'life2 u8)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = ()> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         'life1: 'dynosaur,
@@ -61,38 +62,38 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_elided_lifetimes<'life0, 'life1, 'life2,
             'dynosaur>(&'life0 self, a: &'life1 u8, b: &'life2 u8)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, 'life1: 'dynosaur,
-            'life2: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
+            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait>::multiple_elided_lifetimes(self, a, b))
         }
         fn multiple_named_lifetimes<'a, 'b, 'life0, 'life1,
             'dynosaur>(&'life0 self, a: &'a u8, b: &'b u8, c: &'life1 u8)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'a: 'dynosaur, 'b: 'a + 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'a: 'dynosaur, 'b: 'a + 'dynosaur,
             'life0: 'dynosaur, 'life1: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait>::multiple_named_lifetimes(self, a, b, c))
         }
         fn same_lifetimes_multiple_params<'a, 'life0, 'life1,
             'dynosaur>(&'life0 self, a1: &'a u8, a2: &'a u8, c: &'life1 u8)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                &'a u8> + 'dynosaur>> where 'a: 'dynosaur, 'life0: 'dynosaur,
-            'life1: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = &'a u8> + 'dynosaur>> where 'a: 'dynosaur,
+            'life0: 'dynosaur, 'life1: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait>::same_lifetimes_multiple_params(self, a1, a2, c))
         }
         fn multiple_static_and_anonymous<'life0, 'life1, 'life2,
             'dynosaur>(&'life0 self, a: &'static u8, b: &'life1 u8,
             c: &'life2 u8)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output = ()> +
-                'dynosaur>> where 'life0: 'dynosaur, 'life1: 'dynosaur,
-            'life2: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = ()> + 'dynosaur>> where 'life0: 'dynosaur,
+            'life1: 'dynosaur, 'life2: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as
                         SomeTrait>::multiple_static_and_anonymous(self, a, b, c))
         }
     }
@@ -104,73 +105,80 @@ mod __dynosaur_macro_dynsometrait {
         fn multiple_elided_lifetimes(&self, a: &u8, b: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.multiple_elided_lifetimes(a, b);
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.multiple_elided_lifetimes(a, b);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn multiple_named_lifetimes<'a,
             'b: 'a>(&self, a: &'a u8, b: &'b u8, c: &u8)
             -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> = self.ptr.multiple_named_lifetimes(a, b, c);
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> = self.ptr.multiple_named_lifetimes(a, b, c);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn same_lifetimes_multiple_params<'a>(&self, a1: &'a u8, a2: &'a u8,
             c: &u8) -> impl ::core::future::Future<Output = &'a u8> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    &'a u8> + '_>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = &'a u8> + '_>> =
                 self.ptr.same_lifetimes_multiple_params(a1, a2, c);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    &'a u8> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = &'a u8> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
         fn multiple_static_and_anonymous(&self, a: &'static u8, b: &'_ u8,
             c: &'_ u8) -> impl ::core::future::Future<Output = ()> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + '_>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + '_>> =
                 self.ptr.multiple_static_and_anonymous(a, b, c);
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = ()> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl SomeTrait +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -228,8 +236,8 @@ mod __dynosaur_macro_dynsometrait {
                     SomeTrait>::multiple_static_and_anonymous(self, a, b, c)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn multiple_elided_lifetimes(&self, a: &u8, b: &u8)
             -> impl ::core::future::Future<Output = ()> {
             <DYNOSAUR as SomeTrait>::multiple_elided_lifetimes(self, a, b)

--- a/dynosaur/tests/pass/non-future-impl-traits.stdout
+++ b/dynosaur/tests/pass/non-future-impl-traits.stdout
@@ -8,21 +8,23 @@ trait SomeTrait {
 }
 mod __dynosaur_macro_dynsometrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedSomeTrait {
         fn get_iter<'life0, 'dynosaur>(&'life0 mut self)
-        -> __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + 'dynosaur>
+        -> _Box<dyn Iterator<Item = u8> + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: SomeTrait> ErasedSomeTrait for DYNOSAUR {
         fn get_iter<'life0, 'dynosaur>(&'life0 mut self)
-            ->
-                __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> +
-                'dynosaur> where 'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as
-                        SomeTrait>::get_iter(self))
+            -> _Box<dyn Iterator<Item = u8> + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as SomeTrait>::get_iter(self))
         }
     }
     #[repr(transparent)]
@@ -31,47 +33,34 @@ mod __dynosaur_macro_dynsometrait {
     }
     impl<'dynosaur_struct> SomeTrait for DynSomeTrait<'dynosaur_struct> {
         fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_ {
-            let ret:
-                    __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + '_> =
-                self.ptr.get_iter();
-            let ret:
-                    __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + '_> =
+            let ret: _Box<dyn Iterator<Item = u8> + '_> = self.ptr.get_iter();
+            let ret: _Box<dyn Iterator<Item = u8> + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl SomeTrait +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl SomeTrait + 'dynosaur_struct>)
+            -> _Box<DynSomeTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -92,8 +81,8 @@ mod __dynosaur_macro_dynsometrait {
             <DYNOSAUR as SomeTrait>::get_iter(self)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_ {
             <DYNOSAUR as SomeTrait>::get_iter(self)
         }

--- a/dynosaur/tests/pass/non-future-impl-traits.stdout
+++ b/dynosaur/tests/pass/non-future-impl-traits.stdout
@@ -7,19 +7,22 @@ trait SomeTrait {
     -> impl Iterator<Item = u8> + '_;
 }
 mod __dynosaur_macro_dynsometrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedSomeTrait {
         fn get_iter<'life0, 'dynosaur>(&'life0 mut self)
-        -> Box<dyn Iterator<Item = u8> + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: SomeTrait> ErasedSomeTrait for DYNOSAUR {
         fn get_iter<'life0, 'dynosaur>(&'life0 mut self)
-            -> Box<dyn Iterator<Item = u8> + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as SomeTrait>::get_iter(self))
+            ->
+                __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> +
+                'dynosaur> where 'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as
+                        SomeTrait>::get_iter(self))
         }
     }
     #[repr(transparent)]
@@ -28,37 +31,47 @@ mod __dynosaur_macro_dynsometrait {
     }
     impl<'dynosaur_struct> SomeTrait for DynSomeTrait<'dynosaur_struct> {
         fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_ {
-            let ret: Box<dyn Iterator<Item = u8> + '_> = self.ptr.get_iter();
-            let ret: Box<dyn Iterator<Item = u8> + '_> =
+            let ret:
+                    __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + '_> =
+                self.ptr.get_iter();
+            let ret:
+                    __dynosaur_alloc::boxed::Box<dyn Iterator<Item = u8> + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynSomeTrait<'dynosaur_struct> {
         pub fn new_box(value: impl SomeTrait + 'dynosaur_struct)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SomeTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedSomeTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynSomeTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl SomeTrait + 'dynosaur_struct>)
-            -> Box<DynSomeTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedSomeTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl SomeTrait +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynSomeTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSomeTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl SomeTrait + 'dynosaur_struct))
@@ -79,8 +92,8 @@ mod __dynosaur_macro_dynsometrait {
             <DYNOSAUR as SomeTrait>::get_iter(self)
         }
     }
-    impl<DYNOSAUR: SomeTrait> SomeTrait for Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: SomeTrait> SomeTrait for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn get_iter(&mut self) -> impl Iterator<Item = u8> + '_ {
             <DYNOSAUR as SomeTrait>::get_iter(self)
         }

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
@@ -7,6 +7,10 @@ trait RefOnly {
 }
 mod __dynosaur_macro_dynrefonly {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedRefOnly {
         fn ref_(&self);
@@ -23,35 +27,26 @@ mod __dynosaur_macro_dynrefonly {
     }
     impl<'dynosaur_struct> DynRefOnly<'dynosaur_struct> {
         pub fn new_box(value: impl RefOnly + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynRefOnly<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedRefOnly +
-                    'dynosaur_struct> = value;
+            -> _Box<DynRefOnly<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl RefOnly + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynRefOnly<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedRefOnly +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynRefOnly<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl RefOnly + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynRefOnly<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedRefOnly +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynRefOnly<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl RefOnly + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynRefOnly<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedRefOnly +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl RefOnly + 'dynosaur_struct>)
+            -> _Box<DynRefOnly<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl RefOnly + 'dynosaur_struct))
@@ -72,8 +67,8 @@ mod __dynosaur_macro_dynrefonly {
     impl<DYNOSAUR: RefOnly> RefOnly for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn ref_(&self) { <DYNOSAUR as RefOnly>::ref_(self) }
     }
-    impl<DYNOSAUR: RefOnly> RefOnly for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: RefOnly> RefOnly for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn ref_(&self) { <DYNOSAUR as RefOnly>::ref_(self) }
     }
 }
@@ -86,21 +81,24 @@ trait MutAndRef {
 }
 mod __dynosaur_macro_dynmutandref {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMutAndRef {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MutAndRef> ErasedMutAndRef for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as MutAndRef>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as MutAndRef>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self) -> _Box<dyn Send + 'dynosaur>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as MutAndRef>::ref_(self))
         }
     }
     #[repr(transparent)]
@@ -110,45 +108,34 @@ mod __dynosaur_macro_dynmutandref {
     impl<'dynosaur_struct> MutAndRef for DynMutAndRef<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.ref_();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.ref_();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMutAndRef<'dynosaur_struct> {
         pub fn new_box(value: impl MutAndRef + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMutAndRef<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMutAndRef +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMutAndRef<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MutAndRef + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMutAndRef<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMutAndRef +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMutAndRef<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MutAndRef + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMutAndRef<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMutAndRef +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMutAndRef<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MutAndRef +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMutAndRef<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMutAndRef +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MutAndRef + 'dynosaur_struct>)
+            -> _Box<DynMutAndRef<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MutAndRef + 'dynosaur_struct))
@@ -168,8 +155,8 @@ mod __dynosaur_macro_dynmutandref {
         fn ref_mut(&mut self) { <DYNOSAUR as MutAndRef>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as MutAndRef>::ref_(self) }
     }
-    impl<DYNOSAUR: MutAndRef> MutAndRef for
-        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MutAndRef> MutAndRef for _Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn ref_mut(&mut self) { <DYNOSAUR as MutAndRef>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as MutAndRef>::ref_(self) }
     }
@@ -185,21 +172,24 @@ trait All {
 }
 mod __dynosaur_macro_dynall {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedAll {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
+        -> _Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: All> ErasedAll for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as All>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self)
-            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
-            'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::new(<Self as All>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self) -> _Box<dyn Send + 'dynosaur>
+            where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::new(<Self as All>::ref_(self))
         }
     }
     #[repr(transparent)]
@@ -209,44 +199,34 @@ mod __dynosaur_macro_dynall {
     impl<'dynosaur_struct> All for DynAll<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
-                self.ptr.ref_();
-            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+            let ret: _Box<dyn Send + '_> = self.ptr.ref_();
+            let ret: _Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
         pub fn new_box(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+            -> _Box<DynAll<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynAll<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl All + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynAll<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedAll + 'dynosaur_struct> =
-                value;
+            -> _Rc<DynAll<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl All + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl All + 'dynosaur_struct>)
+            -> _Box<DynAll<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedAll + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))
@@ -264,8 +244,7 @@ mod __dynosaur_macro_dynall {
         fn ref_mut(&mut self) { <DYNOSAUR as All>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as All>::ref_(self) }
     }
-    impl<DYNOSAUR: All> All for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: All> All for _Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn ref_mut(&mut self) { <DYNOSAUR as All>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as All>::ref_(self) }
     }

--- a/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
+++ b/dynosaur/tests/pass/ref_ref_mut_and_box_receivers.stdout
@@ -6,6 +6,7 @@ trait RefOnly {
     fn ref_(&self);
 }
 mod __dynosaur_macro_dynrefonly {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedRefOnly {
         fn ref_(&self);
@@ -22,28 +23,35 @@ mod __dynosaur_macro_dynrefonly {
     }
     impl<'dynosaur_struct> DynRefOnly<'dynosaur_struct> {
         pub fn new_box(value: impl RefOnly + 'dynosaur_struct)
-            -> Box<DynRefOnly<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynRefOnly<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedRefOnly +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl RefOnly + 'dynosaur_struct)
-            -> std::sync::Arc<DynRefOnly<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedRefOnly + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynRefOnly<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedRefOnly +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl RefOnly + 'dynosaur_struct)
-            -> std::rc::Rc<DynRefOnly<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedRefOnly + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynRefOnly<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedRefOnly +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl RefOnly + 'dynosaur_struct>)
-            -> Box<DynRefOnly<'dynosaur_struct>> {
-            let value: Box<dyn ErasedRefOnly + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl RefOnly + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynRefOnly<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedRefOnly +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl RefOnly + 'dynosaur_struct))
@@ -64,7 +72,8 @@ mod __dynosaur_macro_dynrefonly {
     impl<DYNOSAUR: RefOnly> RefOnly for &mut DYNOSAUR where DYNOSAUR: ?Sized {
         fn ref_(&self) { <DYNOSAUR as RefOnly>::ref_(self) }
     }
-    impl<DYNOSAUR: RefOnly> RefOnly for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: RefOnly> RefOnly for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn ref_(&self) { <DYNOSAUR as RefOnly>::ref_(self) }
     }
 }
@@ -76,20 +85,22 @@ trait MutAndRef {
     -> impl Send;
 }
 mod __dynosaur_macro_dynmutandref {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMutAndRef {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: MutAndRef> ErasedMutAndRef for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as MutAndRef>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self) -> Box<dyn Send + 'dynosaur>
-            where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as MutAndRef>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as MutAndRef>::ref_(self))
         }
     }
     #[repr(transparent)]
@@ -99,37 +110,45 @@ mod __dynosaur_macro_dynmutandref {
     impl<'dynosaur_struct> MutAndRef for DynMutAndRef<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.ref_();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.ref_();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMutAndRef<'dynosaur_struct> {
         pub fn new_box(value: impl MutAndRef + 'dynosaur_struct)
-            -> Box<DynMutAndRef<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMutAndRef<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMutAndRef +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MutAndRef + 'dynosaur_struct)
-            -> std::sync::Arc<DynMutAndRef<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynMutAndRef<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedMutAndRef + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMutAndRef +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MutAndRef + 'dynosaur_struct)
-            -> std::rc::Rc<DynMutAndRef<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMutAndRef + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMutAndRef<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMutAndRef +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MutAndRef + 'dynosaur_struct>)
-            -> Box<DynMutAndRef<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMutAndRef + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MutAndRef +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMutAndRef<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMutAndRef +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MutAndRef + 'dynosaur_struct))
@@ -149,8 +168,8 @@ mod __dynosaur_macro_dynmutandref {
         fn ref_mut(&mut self) { <DYNOSAUR as MutAndRef>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as MutAndRef>::ref_(self) }
     }
-    impl<DYNOSAUR: MutAndRef> MutAndRef for Box<DYNOSAUR> where
-        DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MutAndRef> MutAndRef for
+        __dynosaur_alloc::boxed::Box<DYNOSAUR> where DYNOSAUR: ?Sized {
         fn ref_mut(&mut self) { <DYNOSAUR as MutAndRef>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as MutAndRef>::ref_(self) }
     }
@@ -165,20 +184,22 @@ trait All {
     //fn self_box(self: Box<Self>) -> impl Send;
 }
 mod __dynosaur_macro_dynall {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedAll {
         fn ref_mut(&mut self);
         fn ref_<'life0, 'dynosaur>(&'life0 self)
-        -> Box<dyn Send + 'dynosaur>
+        -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
     }
     impl<DYNOSAUR: All> ErasedAll for DYNOSAUR {
         fn ref_mut(&mut self) { <Self as All>::ref_mut(self) }
-        fn ref_<'life0, 'dynosaur>(&'life0 self) -> Box<dyn Send + 'dynosaur>
-            where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::new(<Self as All>::ref_(self))
+        fn ref_<'life0, 'dynosaur>(&'life0 self)
+            -> __dynosaur_alloc::boxed::Box<dyn Send + 'dynosaur> where
+            'life0: 'dynosaur, Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::new(<Self as All>::ref_(self))
         }
     }
     #[repr(transparent)]
@@ -188,35 +209,44 @@ mod __dynosaur_macro_dynall {
     impl<'dynosaur_struct> All for DynAll<'dynosaur_struct> {
         fn ref_mut(&mut self) { self.ptr.ref_mut() }
         fn ref_(&self) -> impl Send {
-            let ret: Box<dyn Send + '_> = self.ptr.ref_();
-            let ret: Box<dyn Send + '_> =
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
+                self.ptr.ref_();
+            let ret: __dynosaur_alloc::boxed::Box<dyn Send + '_> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynAll<'dynosaur_struct> {
         pub fn new_box(value: impl All + 'dynosaur_struct)
-            -> Box<DynAll<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl All + 'dynosaur_struct)
-            -> std::sync::Arc<DynAll<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedAll + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl All + 'dynosaur_struct)
-            -> std::rc::Rc<DynAll<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedAll + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::rc::Rc<DynAll<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedAll + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl All + 'dynosaur_struct>)
-            -> Box<DynAll<'dynosaur_struct>> {
-            let value: Box<dyn ErasedAll + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl All + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynAll<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedAll +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl All + 'dynosaur_struct))
@@ -234,7 +264,8 @@ mod __dynosaur_macro_dynall {
         fn ref_mut(&mut self) { <DYNOSAUR as All>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as All>::ref_(self) }
     }
-    impl<DYNOSAUR: All> All for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: All> All for __dynosaur_alloc::boxed::Box<DYNOSAUR> where
+        DYNOSAUR: ?Sized {
         fn ref_mut(&mut self) { <DYNOSAUR as All>::ref_mut(self) }
         fn ref_(&self) -> impl Send { <DYNOSAUR as All>::ref_(self) }
     }

--- a/dynosaur/tests/pass/trait-variant.stdout
+++ b/dynosaur/tests/pass/trait-variant.stdout
@@ -9,14 +9,15 @@ trait Next {
     -> Option<Self::Item>;
 }
 mod __dynosaur_macro_dynnext {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     #[allow(async_fn_in_trait)]
     trait ErasedNext {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Option<Self::Item>> + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -25,10 +26,10 @@ mod __dynosaur_macro_dynnext {
         type Item = <Self as Next>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            Box::pin(<Self as Next>::next(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as Next>::next(self))
         }
     }
     #[repr(transparent)]
@@ -40,44 +41,47 @@ mod __dynosaur_macro_dynnext {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + '_>> = self.ptr.next();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNext<'dynosaur_struct, Item> {
         pub fn new_box(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> Box<DynNext<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNext<Item = Item> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynNext<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            -> __dynosaur_alloc::sync::Arc<DynNext<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedNext<Item = Item> +
+                    __dynosaur_alloc::sync::Arc<dyn ErasedNext<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynNext<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynNext<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedNext<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedNext<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl Next<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynNext<'dynosaur_struct, Item>> {
-            let value: Box<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
-                value;
+                __dynosaur_alloc::boxed::Box<impl Next<Item = Item> +
+                'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedNext<Item = Item> +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -103,8 +107,8 @@ mod __dynosaur_macro_dynnext {
             <DynNext<'dynosaur_struct, Item> as Next>::next(self)
         }
     }
-    impl<'dynosaur_struct, Item> Next for Box<DynNext<'dynosaur_struct, Item>>
-        {
+    impl<'dynosaur_struct, Item> Next for
+        __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
         type Item = Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
@@ -119,13 +123,14 @@ trait SendNext: Send {
     -> impl ::core::future::Future<Output = Option<Self::Item>> + Send;
 }
 mod __dynosaur_macro_dynsendnext {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedSendNext: Send {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-            Option<Self::Item>> + Send + 'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = Option<Self::Item>> + Send + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -134,10 +139,10 @@ mod __dynosaur_macro_dynsendnext {
         type Item = <Self as SendNext>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                Option<Self::Item>> + Send + 'dynosaur>> where
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = Option<Self::Item>> + Send + 'dynosaur>> where
             'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as SendNext>::next(self))
+            __dynosaur_alloc::boxed::Box::pin(<Self as SendNext>::next(self))
         }
     }
     #[repr(transparent)]
@@ -152,46 +157,53 @@ mod __dynosaur_macro_dynsendnext {
                 impl ::core::future::Future<Output = Option<Self::Item>> +
                 Send {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + Send + '_>> = self.ptr.next();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + Send + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    Option<Self::Item>> + Send + 'static>> =
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = Option<Self::Item>> + Send + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynSendNext<'dynosaur_struct, Item> {
         pub fn new_box(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            -> Box<DynSendNext<'dynosaur_struct, Item>> {
-            let value = Box::new(value);
+            ->
+                __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
             let value:
-                    Box<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSendNext<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            -> std::sync::Arc<DynSendNext<'dynosaur_struct, Item>> {
-            let value = std::sync::Arc::new(value);
+            ->
+                __dynosaur_alloc::sync::Arc<DynSendNext<'dynosaur_struct,
+                Item>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
             let value:
-                    std::sync::Arc<dyn ErasedSendNext<Item = Item> +
-                    'dynosaur_struct> = value;
+                    __dynosaur_alloc::sync::Arc<dyn ErasedSendNext<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            -> std::rc::Rc<DynSendNext<'dynosaur_struct, Item>> {
-            let value = std::rc::Rc::new(value);
+            -> __dynosaur_alloc::rc::Rc<DynSendNext<'dynosaur_struct, Item>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
             let value:
-                    std::rc::Rc<dyn ErasedSendNext<Item = Item> +
+                    __dynosaur_alloc::rc::Rc<dyn ErasedSendNext<Item = Item> +
                     'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                Box<impl SendNext<Item = Item> + 'dynosaur_struct>)
-            -> Box<DynSendNext<'dynosaur_struct, Item>> {
+                __dynosaur_alloc::boxed::Box<impl SendNext<Item = Item> +
+                'dynosaur_struct>)
+            ->
+                __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct,
+                Item>> {
             let value:
-                    Box<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
-                value;
+                    __dynosaur_alloc::boxed::Box<dyn ErasedSendNext<Item =
+                    Item> + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -221,7 +233,8 @@ mod __dynosaur_macro_dynsendnext {
         }
     }
     impl<'dynosaur_struct, Item> SendNext for
-        Box<DynSendNext<'dynosaur_struct, Item>> where Self: Send {
+        __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct, Item>>
+        where Self: Send {
         type Item = Item;
         fn next(&mut self)
             ->

--- a/dynosaur/tests/pass/trait-variant.stdout
+++ b/dynosaur/tests/pass/trait-variant.stdout
@@ -10,14 +10,18 @@ trait Next {
 }
 mod __dynosaur_macro_dynnext {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     #[allow(async_fn_in_trait)]
     trait ErasedNext {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Option<Self::Item>> + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output =
+            Option<Self::Item>> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -26,10 +30,10 @@ mod __dynosaur_macro_dynnext {
         type Item = <Self as Next>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
+                _Pin<_Box<dyn ::core::future::Future<Output =
+                Option<Self::Item>> + 'dynosaur>> where 'life0: 'dynosaur,
             Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as Next>::next(self))
+            _Box::pin(<Self as Next>::next(self))
         }
     }
     #[repr(transparent)]
@@ -41,47 +45,42 @@ mod __dynosaur_macro_dynnext {
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + '_>> = self.ptr.next();
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + 'static>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynNext<'dynosaur_struct, Item> {
         pub fn new_box(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNext<Item = Item> +
-                    'dynosaur_struct> = value;
+            -> _Box<DynNext<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynNext<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedNext<Item = Item> +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynNext<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl Next<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynNext<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedNext<Item = Item> +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynNext<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl Next<Item = Item> +
-                'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedNext<Item = Item> +
-                    'dynosaur_struct> = value;
+                _Box<impl Next<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynNext<'dynosaur_struct, Item>> {
+            let value: _Box<dyn ErasedNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -108,7 +107,7 @@ mod __dynosaur_macro_dynnext {
         }
     }
     impl<'dynosaur_struct, Item> Next for
-        __dynosaur_alloc::boxed::Box<DynNext<'dynosaur_struct, Item>> {
+        _Box<DynNext<'dynosaur_struct, Item>> {
         type Item = Item;
         fn next(&mut self)
             -> impl ::core::future::Future<Output = Option<Self::Item>> {
@@ -124,13 +123,17 @@ trait SendNext: Send {
 }
 mod __dynosaur_macro_dynsendnext {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedSendNext: Send {
         type Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
         ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = Option<Self::Item>> + Send + 'dynosaur>>
+            _Pin<_Box<dyn ::core::future::Future<Output =
+            Option<Self::Item>> + Send + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -139,10 +142,10 @@ mod __dynosaur_macro_dynsendnext {
         type Item = <Self as SendNext>::Item;
         fn next<'life0, 'dynosaur>(&'life0 mut self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = Option<Self::Item>> + Send + 'dynosaur>> where
+                _Pin<_Box<dyn ::core::future::Future<Output =
+                Option<Self::Item>> + Send + 'dynosaur>> where
             'life0: 'dynosaur, Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as SendNext>::next(self))
+            _Box::pin(<Self as SendNext>::next(self))
         }
     }
     #[repr(transparent)]
@@ -157,53 +160,46 @@ mod __dynosaur_macro_dynsendnext {
                 impl ::core::future::Future<Output = Option<Self::Item>> +
                 Send {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + Send + '_>> = self.ptr.next();
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + Send + '_>> = self.ptr.next();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = Option<Self::Item>> + Send + 'static>> =
+                    _Pin<_Box<dyn ::core::future::Future<Output =
+                    Option<Self::Item>> + Send + 'static>> =
                 unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct, Item> DynSendNext<'dynosaur_struct, Item> {
         pub fn new_box(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
+            -> _Box<DynSendNext<'dynosaur_struct, Item>> {
+            let value = _Box::new(value);
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSendNext<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            ->
-                __dynosaur_alloc::sync::Arc<DynSendNext<'dynosaur_struct,
-                Item>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
+            -> _Arc<DynSendNext<'dynosaur_struct, Item>> {
+            let value = _Arc::new(value);
             let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedSendNext<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Arc<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl SendNext<Item = Item> + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynSendNext<'dynosaur_struct, Item>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
+            -> _Rc<DynSendNext<'dynosaur_struct, Item>> {
+            let value = _Rc::new(value);
             let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedSendNext<Item = Item> +
-                    'dynosaur_struct> = value;
+                    _Rc<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl SendNext<Item = Item> +
-                'dynosaur_struct>)
-            ->
-                __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct,
-                Item>> {
+                _Box<impl SendNext<Item = Item> + 'dynosaur_struct>)
+            -> _Box<DynSendNext<'dynosaur_struct, Item>> {
             let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedSendNext<Item =
-                    Item> + 'dynosaur_struct> = value;
+                    _Box<dyn ErasedSendNext<Item = Item> + 'dynosaur_struct> =
+                value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value:
@@ -233,8 +229,7 @@ mod __dynosaur_macro_dynsendnext {
         }
     }
     impl<'dynosaur_struct, Item> SendNext for
-        __dynosaur_alloc::boxed::Box<DynSendNext<'dynosaur_struct, Item>>
-        where Self: Send {
+        _Box<DynSendNext<'dynosaur_struct, Item>> where Self: Send {
         type Item = Item;
         fn next(&mut self)
             ->

--- a/dynosaur/tests/pass/visibility.stdout
+++ b/dynosaur/tests/pass/visibility.stdout
@@ -10,12 +10,14 @@ trait MyTrait {
 }
 mod __dynosaur_macro_dynmytrait {
     extern crate alloc as __dynosaur_alloc;
+    use __dynosaur_alloc::boxed::Box as _Box;
+    use __dynosaur_alloc::rc::Rc as _Rc;
+    use __dynosaur_alloc::sync::Arc as _Arc;
+    use ::core::pin::Pin as _Pin;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
-        ->
-            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-            = i32> + 'dynosaur>>
+        -> _Pin<_Box<dyn ::core::future::Future<Output = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -23,10 +25,9 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
-            Self: 'dynosaur {
-            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
+                _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
+            _Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -36,45 +37,36 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + '_>> = self.ptr.foo();
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> + '_>> =
+                self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
-                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    _Pin<_Box<dyn ::core::future::Future<Output = i32> +
+                    'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::boxed::Box::new(value);
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value = _Box::new(value);
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::sync::Arc::new(value);
-            let value:
-                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Arc::new(value);
+            let value: _Arc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = __dynosaur_alloc::rc::Rc::new(value);
-            let value:
-                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+            -> _Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = _Rc::new(value);
+            let value: _Rc<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value:
-                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
-            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
-            let value:
-                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
-                    'dynosaur_struct> = value;
+        pub const fn from_box(value: _Box<impl MyTrait + 'dynosaur_struct>)
+            -> _Box<DynMyTrait<'dynosaur_struct>> {
+            let value: _Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -99,8 +91,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
-        where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for _Box<DYNOSAUR> where DYNOSAUR: ?Sized
+        {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur/tests/pass/visibility.stdout
+++ b/dynosaur/tests/pass/visibility.stdout
@@ -9,12 +9,13 @@ trait MyTrait {
     -> i32;
 }
 mod __dynosaur_macro_dynmytrait {
+    extern crate alloc as __dynosaur_alloc;
     use super::*;
     trait ErasedMyTrait {
         fn foo<'life0, 'dynosaur>(&'life0 self)
         ->
-            ::core::pin::Pin<Box<dyn ::core::future::Future<Output = i32> +
-            'dynosaur>>
+            ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+            = i32> + 'dynosaur>>
         where
         'life0: 'dynosaur,
         Self: 'dynosaur;
@@ -22,9 +23,10 @@ mod __dynosaur_macro_dynmytrait {
     impl<DYNOSAUR: MyTrait> ErasedMyTrait for DYNOSAUR {
         fn foo<'life0, 'dynosaur>(&'life0 self)
             ->
-                ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                i32> + 'dynosaur>> where 'life0: 'dynosaur, Self: 'dynosaur {
-            Box::pin(<Self as MyTrait>::foo(self))
+                ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                = i32> + 'dynosaur>> where 'life0: 'dynosaur,
+            Self: 'dynosaur {
+            __dynosaur_alloc::boxed::Box::pin(<Self as MyTrait>::foo(self))
         }
     }
     #[repr(transparent)]
@@ -34,38 +36,45 @@ mod __dynosaur_macro_dynmytrait {
     impl<'dynosaur_struct> MyTrait for DynMyTrait<'dynosaur_struct> {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + '_>> = self.ptr.foo();
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + '_>> = self.ptr.foo();
             let ret:
-                    ::core::pin::Pin<Box<dyn ::core::future::Future<Output =
-                    i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
+                    ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output
+                    = i32> + 'static>> = unsafe { ::core::mem::transmute(ret) };
             ret
         }
     }
     impl<'dynosaur_struct> DynMyTrait<'dynosaur_struct> {
         pub fn new_box(value: impl MyTrait + 'dynosaur_struct)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value = Box::new(value);
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::boxed::Box::new(value);
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_arc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::sync::Arc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::sync::Arc::new(value);
-            let value: std::sync::Arc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::sync::Arc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::sync::Arc::new(value);
+            let value:
+                    __dynosaur_alloc::sync::Arc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub fn new_rc(value: impl MyTrait + 'dynosaur_struct)
-            -> std::rc::Rc<DynMyTrait<'dynosaur_struct>> {
-            let value = std::rc::Rc::new(value);
-            let value: std::rc::Rc<dyn ErasedMyTrait + 'dynosaur_struct> =
-                value;
+            -> __dynosaur_alloc::rc::Rc<DynMyTrait<'dynosaur_struct>> {
+            let value = __dynosaur_alloc::rc::Rc::new(value);
+            let value:
+                    __dynosaur_alloc::rc::Rc<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
-        pub const fn from_box(value: Box<impl MyTrait + 'dynosaur_struct>)
-            -> Box<DynMyTrait<'dynosaur_struct>> {
-            let value: Box<dyn ErasedMyTrait + 'dynosaur_struct> = value;
+        pub const fn from_box(value:
+                __dynosaur_alloc::boxed::Box<impl MyTrait + 'dynosaur_struct>)
+            -> __dynosaur_alloc::boxed::Box<DynMyTrait<'dynosaur_struct>> {
+            let value:
+                    __dynosaur_alloc::boxed::Box<dyn ErasedMyTrait +
+                    'dynosaur_struct> = value;
             unsafe { ::core::mem::transmute(value) }
         }
         pub const fn from_ref(value: &(impl MyTrait + 'dynosaur_struct))
@@ -90,7 +99,8 @@ mod __dynosaur_macro_dynmytrait {
             <DYNOSAUR as MyTrait>::foo(self)
         }
     }
-    impl<DYNOSAUR: MyTrait> MyTrait for Box<DYNOSAUR> where DYNOSAUR: ?Sized {
+    impl<DYNOSAUR: MyTrait> MyTrait for __dynosaur_alloc::boxed::Box<DYNOSAUR>
+        where DYNOSAUR: ?Sized {
         fn foo(&self) -> impl ::core::future::Future<Output = i32> {
             <DYNOSAUR as MyTrait>::foo(self)
         }

--- a/dynosaur_derive/src/expand.rs
+++ b/dynosaur_derive/src/expand.rs
@@ -26,10 +26,12 @@ use syn::{
 ///
 /// ```rust
 /// # extern crate alloc as __dynosaur_alloc;
+/// # use __dynosaur_alloc::boxed::Box as _Box;
+/// # use std::pin::Pin as _Pin;
 /// trait ErasedMyTrait {
 ///     fn foo<'life0, 'dynosaur>(&'life0 self)
 ///     ->
-///         ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output = i32> +
+///         _Pin<_Box<dyn ::core::future::Future<Output = i32> +
 ///         'dynosaur>>
 ///     where
 ///     'life0: 'dynosaur,
@@ -59,9 +61,9 @@ fn expand_apits(sig: &mut Signature) {
                 let bounds = expand_bounds(&type_impl_trait.bounds, Some(lifetime_ident));
 
                 arg.ty = if is_future(type_impl_trait) {
-                    parse_quote! { ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn #bounds>> }
+                    parse_quote! { _Pin<_Box<dyn #bounds>> }
                 } else {
-                    parse_quote! { __dynosaur_alloc::boxed::Box<dyn #bounds> }
+                    parse_quote! { _Box<dyn #bounds> }
                 };
             }
         }
@@ -185,9 +187,9 @@ pub(crate) fn expand_sig_ret_ty(sig: &Signature, lifetime_ident: &str) -> Type {
         let bounds = expand_ret_bounds(sig, Some(lifetime_ident));
 
         if is_async {
-            parse_quote! { ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn #bounds>> }
+            parse_quote! { _Pin<_Box<dyn #bounds>> }
         } else {
-            parse_quote! { __dynosaur_alloc::boxed::Box<dyn #bounds> }
+            parse_quote! { _Box<dyn #bounds> }
         }
     } else {
         match &sig.output {
@@ -292,9 +294,9 @@ fn expand_invoke_args(sig: &Signature, mode: &InvokeArgsMode) -> Vec<TokenStream
                     } else {
                         if let Type::ImplTrait(type_impl_trait) = &*pat_type.ty {
                             if is_future(type_impl_trait) {
-                                args.push(quote! { __dynosaur_alloc::boxed::Box::pin(#arg) });
+                                args.push(quote! { _Box::pin(#arg) });
                             } else {
-                                args.push(quote! { __dynosaur_alloc::boxed::Box::new(#arg) });
+                                args.push(quote! { _Box::new(#arg) });
                             }
                         } else {
                             args.push(quote! { #arg });
@@ -331,11 +333,11 @@ pub(crate) fn expand_blanket_impl_fn(item_trait: &ItemTrait, sig: &mut Signature
 
     let value = if is_async {
         quote! {
-            __dynosaur_alloc::boxed::Box::pin(#value)
+            _Box::pin(#value)
         }
     } else if is_rpit {
         quote! {
-            __dynosaur_alloc::boxed::Box::new(#value)
+            _Box::new(#value)
         }
     } else {
         value

--- a/dynosaur_derive/src/expand.rs
+++ b/dynosaur_derive/src/expand.rs
@@ -25,10 +25,11 @@ use syn::{
 /// into:
 ///
 /// ```rust
+/// # extern crate alloc as __dynosaur_alloc;
 /// trait ErasedMyTrait {
 ///     fn foo<'life0, 'dynosaur>(&'life0 self)
 ///     ->
-///         ::core::pin::Pin<Box<dyn ::core::future::Future<Output = i32> +
+///         ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn ::core::future::Future<Output = i32> +
 ///         'dynosaur>>
 ///     where
 ///     'life0: 'dynosaur,
@@ -58,9 +59,9 @@ fn expand_apits(sig: &mut Signature) {
                 let bounds = expand_bounds(&type_impl_trait.bounds, Some(lifetime_ident));
 
                 arg.ty = if is_future(type_impl_trait) {
-                    parse_quote! { ::core::pin::Pin<Box<dyn #bounds>> }
+                    parse_quote! { ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn #bounds>> }
                 } else {
-                    parse_quote! { Box<dyn #bounds> }
+                    parse_quote! { __dynosaur_alloc::boxed::Box<dyn #bounds> }
                 };
             }
         }
@@ -184,9 +185,9 @@ pub(crate) fn expand_sig_ret_ty(sig: &Signature, lifetime_ident: &str) -> Type {
         let bounds = expand_ret_bounds(sig, Some(lifetime_ident));
 
         if is_async {
-            parse_quote! { ::core::pin::Pin<Box<dyn #bounds>> }
+            parse_quote! { ::core::pin::Pin<__dynosaur_alloc::boxed::Box<dyn #bounds>> }
         } else {
-            parse_quote! { Box<dyn #bounds> }
+            parse_quote! { __dynosaur_alloc::boxed::Box<dyn #bounds> }
         }
     } else {
         match &sig.output {
@@ -291,9 +292,9 @@ fn expand_invoke_args(sig: &Signature, mode: &InvokeArgsMode) -> Vec<TokenStream
                     } else {
                         if let Type::ImplTrait(type_impl_trait) = &*pat_type.ty {
                             if is_future(type_impl_trait) {
-                                args.push(quote! { Box::pin(#arg) });
+                                args.push(quote! { __dynosaur_alloc::boxed::Box::pin(#arg) });
                             } else {
-                                args.push(quote! { Box::new(#arg) });
+                                args.push(quote! { __dynosaur_alloc::boxed::Box::new(#arg) });
                             }
                         } else {
                             args.push(quote! { #arg });
@@ -330,11 +331,11 @@ pub(crate) fn expand_blanket_impl_fn(item_trait: &ItemTrait, sig: &mut Signature
 
     let value = if is_async {
         quote! {
-            Box::pin(#value)
+            __dynosaur_alloc::boxed::Box::pin(#value)
         }
     } else if is_rpit {
         quote! {
-            Box::new(#value)
+            __dynosaur_alloc::boxed::Box::new(#value)
         }
     } else {
         value

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -154,12 +154,13 @@ impl Parse for Bridge {
 /// The `Dyn` struct produced by this macro has the following constructors:
 ///
 /// ```
+/// # extern crate alloc;
 /// # struct DynTrait<'a>(&'a i32);
 /// # trait Trait {}
 /// impl<'a> DynTrait<'a> {
 ///     fn new_box(from: impl Trait) -> Box<Self> { todo!() }
-///     fn new_arc(from: impl Trait) -> std::sync::Arc<Self> { todo!() }
-///     fn new_rc(from: impl Trait) -> std::rc::Rc<Self> { todo!() }
+///     fn new_arc(from: impl Trait) -> alloc::sync::Arc<Self> { todo!() }
+///     fn new_rc(from: impl Trait) -> alloc::rc::Rc<Self> { todo!() }
 ///
 ///     fn from_box(from: Box<impl Trait + 'a>) -> Box<Self> { todo!() }
 ///     fn from_ref(from: &'a impl Trait) -> &'a Self { todo!() }
@@ -311,6 +312,7 @@ pub fn dynosaur(
         #item_trait
 
         mod #dynosaur_mod {
+            extern crate alloc as __dynosaur_alloc;
             use super::*;
             #erased_trait
             #erased_trait_blanket_impl
@@ -482,26 +484,26 @@ fn mk_struct_inherent_impl(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
     quote! {
         impl #struct_with_bounds_params #struct_ident #struct_params
         {
-            pub fn new_box(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> Box<#struct_ident #struct_params> {
-                let value = Box::new(value);
-                let value: Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_box(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::boxed::Box<#struct_ident #struct_params> {
+                let value = __dynosaur_alloc::boxed::Box::new(value);
+                let value: __dynosaur_alloc::boxed::Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn new_arc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> std::sync::Arc<#struct_ident #struct_params> {
-                let value = std::sync::Arc::new(value);
-                let value: std::sync::Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_arc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::sync::Arc<#struct_ident #struct_params> {
+                let value = __dynosaur_alloc::sync::Arc::new(value);
+                let value: __dynosaur_alloc::sync::Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> std::rc::Rc<#struct_ident #struct_params> {
-                let value = std::rc::Rc::new(value);
-                let value: std::rc::Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::rc::Rc<#struct_ident #struct_params> {
+                let value = __dynosaur_alloc::rc::Rc::new(value);
+                let value: __dynosaur_alloc::rc::Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub const fn from_box(value: Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> Box<#struct_ident #struct_params> {
-                let value: Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub const fn from_box(value: __dynosaur_alloc::boxed::Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> __dynosaur_alloc::boxed::Box<#struct_ident #struct_params> {
+                let value: __dynosaur_alloc::boxed::Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
@@ -681,7 +683,7 @@ fn mk_box_blanket_impl(
     if self_receiver.should_gen_box_self() {
         result.extend(
             quote! {
-                impl #blanket_impl_generics #item_trait_ident #trait_generics for Box<#blanket #blanket_params #blanket_where_clause> #where_bounds {
+                impl #blanket_impl_generics #item_trait_ident #trait_generics for __dynosaur_alloc::boxed::Box<#blanket #blanket_params #blanket_where_clause> #where_bounds {
                     #(#items)*
                 }
             }

--- a/dynosaur_derive/src/lib.rs
+++ b/dynosaur_derive/src/lib.rs
@@ -313,6 +313,10 @@ pub fn dynosaur(
 
         mod #dynosaur_mod {
             extern crate alloc as __dynosaur_alloc;
+            use __dynosaur_alloc::boxed::Box as _Box;
+            use __dynosaur_alloc::rc::Rc as _Rc;
+            use __dynosaur_alloc::sync::Arc as _Arc;
+            use ::core::pin::Pin as _Pin;
             use super::*;
             #erased_trait
             #erased_trait_blanket_impl
@@ -484,26 +488,26 @@ fn mk_struct_inherent_impl(struct_ident: &Ident, item_trait: &ItemTrait) -> Toke
     quote! {
         impl #struct_with_bounds_params #struct_ident #struct_params
         {
-            pub fn new_box(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::boxed::Box<#struct_ident #struct_params> {
-                let value = __dynosaur_alloc::boxed::Box::new(value);
-                let value: __dynosaur_alloc::boxed::Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_box(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Box<#struct_ident #struct_params> {
+                let value = _Box::new(value);
+                let value: _Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn new_arc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::sync::Arc<#struct_ident #struct_params> {
-                let value = __dynosaur_alloc::sync::Arc::new(value);
-                let value: __dynosaur_alloc::sync::Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_arc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Arc<#struct_ident #struct_params> {
+                let value = _Arc::new(value);
+                let value: _Arc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> __dynosaur_alloc::rc::Rc<#struct_ident #struct_params> {
-                let value = __dynosaur_alloc::rc::Rc::new(value);
-                let value: __dynosaur_alloc::rc::Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub fn new_rc(value: impl #trait_ident #trait_params + 'dynosaur_struct) -> _Rc<#struct_ident #struct_params> {
+                let value = _Rc::new(value);
+                let value: _Rc<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
-            pub const fn from_box(value: __dynosaur_alloc::boxed::Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> __dynosaur_alloc::boxed::Box<#struct_ident #struct_params> {
-                let value: __dynosaur_alloc::boxed::Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
+            pub const fn from_box(value: _Box<impl #trait_ident #trait_params + 'dynosaur_struct>) -> _Box<#struct_ident #struct_params> {
+                let value: _Box<dyn #erased_trait_ident #trait_params + 'dynosaur_struct> = value;
                 unsafe { ::core::mem::transmute(value) }
             }
 
@@ -683,7 +687,7 @@ fn mk_box_blanket_impl(
     if self_receiver.should_gen_box_self() {
         result.extend(
             quote! {
-                impl #blanket_impl_generics #item_trait_ident #trait_generics for __dynosaur_alloc::boxed::Box<#blanket #blanket_params #blanket_where_clause> #where_bounds {
+                impl #blanket_impl_generics #item_trait_ident #trait_generics for _Box<#blanket #blanket_params #blanket_where_clause> #where_bounds {
                     #(#items)*
                 }
             }


### PR DESCRIPTION
Tried using dynosaur in a no_std + alloc – and got a failure I can't work around because macro expansions use std. Here is my attempt to fix it.